### PR TITLE
Afegida pàgina de rànquing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="manifest" href="manifest.json" />
   <link rel="stylesheet" href="style.css" />
-  <title>La meva PWA</title>
+  <title>Billar Foment Martinenc</title>
 </head>
 <body>
-  <h1>Benvingut/da a la meva PWA!</h1>
+  <h1>Billar Foment Martinenc</h1>
+  <div id="menu">
+    <button id="btn-ranking">Veure rànquing</button>
+    <!-- aquí es poden afegir més botons en el futur -->
+  </div>
+  <div id="content"></div>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -5,3 +5,35 @@ if ("serviceWorker" in navigator) {
       .catch(err => console.error("Error al registrar el SW:", err));
   });
 }
+
+function mostraRanquing() {
+  fetch('ranquing.json')
+    .then(res => res.json())
+    .then(dades => {
+      const cont = document.getElementById('content');
+      cont.innerHTML = '';
+      const taula = document.createElement('table');
+      const cap = document.createElement('tr');
+      ['Any','Modalitat','Posició','Jugador','Mitjana'].forEach(t => {
+        const th = document.createElement('th');
+        th.textContent = t;
+        cap.appendChild(th);
+      });
+      taula.appendChild(cap);
+      dades.forEach(reg => {
+        const tr = document.createElement('tr');
+        ['Any','Modalitat','Posició','Jugador','Mitjana'].forEach(clau => {
+          const td = document.createElement('td');
+          td.textContent = reg[clau];
+          tr.appendChild(td);
+        });
+        taula.appendChild(tr);
+      });
+      cont.appendChild(taula);
+    })
+    .catch(err => {
+      console.error('Error carregant el ranquing', err);
+    });
+}
+
+document.getElementById('btn-ranking').addEventListener('click', mostraRanquing);

--- a/ranquing.json
+++ b/ranquing.json
@@ -1,0 +1,8766 @@
+[
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "GARCÍA",
+    "Mitjana": "0.54900000000000004"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.45600000000000002"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.40100000000000002"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.38800000000000001"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "VIVAS",
+    "Mitjana": "0.38800000000000001"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "DONADEU",
+    "Mitjana": "0.26700000000000002"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.23300000000000001"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.22"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "PUIG",
+    "Mitjana": "0.2"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.19800000000000001"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "TARES",
+    "Mitjana": "0.183"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "TABERNER",
+    "Mitjana": "0.183"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "MIR",
+    "Mitjana": "0.159"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "MAGRIÑA",
+    "Mitjana": "0.153"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.14799999999999999"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "MARTÍ",
+    "Mitjana": "9.5000000000000001E-2"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.495"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.41499999999999998"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "VIVAS",
+    "Mitjana": "0.36799999999999999"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.308"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "RUIZ",
+    "Mitjana": "0.23200000000000001"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "J. GRAU",
+    "Mitjana": "0.22800000000000001"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "PUIG",
+    "Mitjana": "0.20699999999999999"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.19500000000000001"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.17599999999999999"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "TARES",
+    "Mitjana": "0.14000000000000001"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.12"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.42399999999999999"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.38800000000000001"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "VIVAS",
+    "Mitjana": "0.32"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.31900000000000001"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.28299999999999997"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.26900000000000002"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.24299999999999999"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.23599999999999999"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.22900000000000001"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "PUIG",
+    "Mitjana": "0.22800000000000001"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "0.22"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.17299999999999999"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "RUIZ",
+    "Mitjana": "0.11600000000000001"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "TARES",
+    "Mitjana": "0.218"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "MIR",
+    "Mitjana": "0.214"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.186"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "TABERNER",
+    "Mitjana": "0.17399999999999999"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.12"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "R. FINA",
+    "Mitjana": "8.2000000000000003E-2"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "MARTÍ",
+    "Mitjana": "7.0000000000000007E-2"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.33600000000000002"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.33300000000000002"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.33100000000000002"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "0.32900000000000001"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.32500000000000001"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "PUIG",
+    "Mitjana": "0.27400000000000002"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.27100000000000002"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "J. GRAU",
+    "Mitjana": "0.26400000000000001"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.25900000000000001"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.23699999999999999"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.219"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "REAL",
+    "Mitjana": "0.19600000000000001"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "RUIZ",
+    "Mitjana": "0.23499999999999999"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "TARES",
+    "Mitjana": "0.21299999999999999"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "MIR",
+    "Mitjana": "0.17699999999999999"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.17399999999999999"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "SERRA",
+    "Mitjana": "0.16700000000000001"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.14899999999999999"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.12"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "QUEVEDO",
+    "Mitjana": "0.11600000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.45300000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.39400000000000002"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.379"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.33500000000000002"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.313"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "PALAU",
+    "Mitjana": "0.29799999999999999"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "SELGAS",
+    "Mitjana": "0.28699999999999998"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "0.27700000000000002"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.253"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "PUIG",
+    "Mitjana": "0.254"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.24199999999999999"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.20399999999999999"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.182"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.16900000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.20799999999999999"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "REAL",
+    "Mitjana": "0.20799999999999999"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "BARRIENTOS",
+    "Mitjana": "0.19900000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.13600000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "QUEVEDO",
+    "Mitjana": "0.1"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "MARTÍ",
+    "Mitjana": "7.3999999999999996E-2"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "ALBARRACIN",
+    "Mitjana": "0.53"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "DURAN",
+    "Mitjana": "0.5"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.45"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.41"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.4"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "VIDAL",
+    "Mitjana": "0.37"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.32"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "ROVIROSA",
+    "Mitjana": "0.3"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "J. GRAU",
+    "Mitjana": "0.28000000000000003"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "VIVAS",
+    "Mitjana": "0.27400000000000002"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.27179999999999999"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.27129999999999999"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "PALAU",
+    "Mitjana": "0.26"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.24"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "SELGAS",
+    "Mitjana": "0.14000000000000001"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "TARES",
+    "Mitjana": "0.22"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "HERNANDEZ",
+    "Mitjana": "0.2"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.18"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "BARRIENTOS",
+    "Mitjana": "0.17"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.14499999999999999"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.14399999999999999"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.11"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.55000000000000004"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "DURAN",
+    "Mitjana": "0.46"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.38700000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.38200000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.377"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "PALAU",
+    "Mitjana": "0.33600000000000002"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.30199999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.29199999999999998"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "J. GRAU",
+    "Mitjana": "0.28100000000000003"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "VIVAS",
+    "Mitjana": "0.28000000000000003"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "ROVIROSA",
+    "Mitjana": "0.27100000000000002"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.26100000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.253"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "SERRA",
+    "Mitjana": "0.252"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "HERNANDEZ",
+    "Mitjana": "0.23100000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "SELGAS",
+    "Mitjana": "0.22800000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "RODRÍGUEZ",
+    "Mitjana": "0.22700000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "SOLANES",
+    "Mitjana": "0.22500000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.22500000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.21"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.188"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "BARRIENTOS",
+    "Mitjana": "0.16800000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "TARES",
+    "Mitjana": "0.16400000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.159"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "GÓMEZ",
+    "Mitjana": "0.153"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.14399999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "MARTÍNEZ",
+    "Mitjana": "0.14399999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.13700000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "MIR",
+    "Mitjana": "0.13700000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.13500000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "PRAT",
+    "Mitjana": "0.13200000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "J. ARMENGOL",
+    "Mitjana": "0.112"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "NOGUER",
+    "Mitjana": "8.5000000000000006E-2"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "MARTÍ",
+    "Mitjana": "7.0000000000000007E-2"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "R. GRAU",
+    "Mitjana": "0.47199999999999998"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.443"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.41499999999999998"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.40600000000000003"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.38400000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.35199999999999998"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "A. ALUJA",
+    "Mitjana": "0.35"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.35"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.33600000000000002"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.318"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "M. PALAU",
+    "Mitjana": "0.315"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "P. SERRA",
+    "Mitjana": "0.28199999999999997"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.25900000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.25800000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.24399999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.23400000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.23300000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.22900000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.22700000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.215"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "F. GÓMEZ",
+    "Mitjana": "0.21"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.187"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.182"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.16700000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.16400000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "J. MIR",
+    "Mitjana": "0.16300000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "J. SANZ",
+    "Mitjana": "0.14399999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "P. BALLESTER",
+    "Mitjana": "0.13700000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.129"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.11899999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.11700000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "M. PRAT",
+    "Mitjana": "0.11"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.45800000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.42599999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.38400000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.33700000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "E. RODRÍGUEZ",
+    "Mitjana": "0.34699999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.34100000000000003"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.33800000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "A. PORTA",
+    "Mitjana": "0.33700000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.317"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "R. GRAU",
+    "Mitjana": "0.30399999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "0.29399999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.28999999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.28799999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.28699999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.28599999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.27200000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.249"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.247"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.24199999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "P. SERRA",
+    "Mitjana": "0.23899999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.23100000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.22900000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.20799999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.19600000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "C. GIRÓ",
+    "Mitjana": "0.188"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.185"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.17599999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "F. GÓMEZ",
+    "Mitjana": "0.17499999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "M. BRUQUETAS",
+    "Mitjana": "0.17"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.155"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "M. PRAT",
+    "Mitjana": "0.14499999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.13900000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "P. BALLESTER",
+    "Mitjana": "0.13700000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.122"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.104"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.443"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.42499999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "V. HAMMER",
+    "Mitjana": "0.39900000000000002"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.38100000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.35499999999999998"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.33700000000000002"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.32300000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "R. GRAU",
+    "Mitjana": "0.30199999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.28699999999999998"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.28499999999999998"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.27400000000000002"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.26800000000000002"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.22900000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.221"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.214"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.214"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.214"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "P. SERRA",
+    "Mitjana": "0.21199999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.20599999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "M. BRUQUETAS",
+    "Mitjana": "0.20100000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.19900000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.193"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.189"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.188"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.17599999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.17"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.155"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "P. BALLESTER",
+    "Mitjana": "0.14799999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.14399999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.13800000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.13500000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.13100000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "J. ARMENGOL",
+    "Mitjana": "0.13"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.108"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "5.8999999999999997E-2"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.45800000000000002"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.40200000000000002"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.38800000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.375"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.35599999999999998"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.35099999999999998"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.33300000000000002"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "R. GRAU",
+    "Mitjana": "0.32600000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "V. HAMMER",
+    "Mitjana": "0.32300000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.32100000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.307"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.30399999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.29599999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "A. PORTA",
+    "Mitjana": "0.28799999999999998"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "E. LUENGO",
+    "Mitjana": "0.28199999999999997"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "E. RODRÍGUEZ",
+    "Mitjana": "0.26200000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.25600000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.254"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.252"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.247"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.22600000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.222"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.221"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.217"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.21199999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.21199999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.20899999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.193"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.17599999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.158"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "P. BALLESTER",
+    "Mitjana": "0.14899999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.14699999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.13400000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.128"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "J. ARMENGOL",
+    "Mitjana": "0.123"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "3 BANDES",
+    "Posició": "36",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "4.1000000000000002E-2"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.439"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.41699999999999998"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.38"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.36299999999999999"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "E. RODRÍGUEZ",
+    "Mitjana": "0.34799999999999998"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.33100000000000002"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.32200000000000001"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "V. HAMMER",
+    "Mitjana": "0.318"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.313"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.309"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.29599999999999999"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.29299999999999998"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.28199999999999997"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "A. PORTA",
+    "Mitjana": "0.27900000000000003"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.27"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.26"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "R. GRAU",
+    "Mitjana": "0.26"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.24399999999999999"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.24399999999999999"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "A. CAMPILLO",
+    "Mitjana": "0.23699999999999999"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.22500000000000001"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.223"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.216"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.214"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.20799999999999999"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.20499999999999999"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.20200000000000001"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.20200000000000001"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.2"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "S. MARÍN",
+    "Mitjana": "0.16600000000000001"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "M. BRUQUETAS",
+    "Mitjana": "0.159"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.156"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.14799999999999999"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.14599999999999999"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.108"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "36",
+    "Jugador": "P. BALLESTER",
+    "Mitjana": "0.106"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "37",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "8.4000000000000005E-2"
+  },
+  {
+    "Any": "2015",
+    "Modalitat": "3 BANDES",
+    "Posició": "38",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "4.7E-2"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "A. GÓMEZ",
+    "Mitjana": "0.49684210526315792"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.45416666666666672"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J.M. CAMPOS",
+    "Mitjana": "0.42885375494071148"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.39010989010989011"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "L. CHUECOS",
+    "Mitjana": "0.388671875"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "J.L. ROSERÓ",
+    "Mitjana": "0.33267326732673269"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.33153153153153148"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.30412371134020622"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "A. MELGAREJO",
+    "Mitjana": "0.3"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "J. VILA",
+    "Mitjana": "0.2880658436213992"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "A. FUENTES",
+    "Mitjana": "0.28545454545454552"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "0.28119180633147112"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.26719056974459732"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.26689774696707108"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.25486725663716808"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.24319419237749551"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.24231464737793851"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.23622047244094491"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "J. VEZA",
+    "Mitjana": "0.2281021897810219"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "E. GARCÍA",
+    "Mitjana": "0.2196078431372549"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.21777003484320559"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.20304568527918779"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.20202020202020199"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "P. FERRÀS",
+    "Mitjana": "0.18166939443535191"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.17123287671232881"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "J. GÓMEZ",
+    "Mitjana": "0.16987179487179491"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "M. GONZALVO",
+    "Mitjana": "0.16856060606060599"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "S. MARÍN",
+    "Mitjana": "0.16588419405320809"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.16428571428571431"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.16267123287671231"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.16236722306525039"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "A. MEDINA",
+    "Mitjana": "0.15957446808510639"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "A. MORA",
+    "Mitjana": "0.1558641975308642"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.15580286168521459"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "J. IBÁÑEZ",
+    "Mitjana": "0.1548599670510708"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "36",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.12168486739469581"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "37",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.11492537313432841"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "38",
+    "Jugador": "A. GARCÍA",
+    "Mitjana": "0.11248073959938371"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "39",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.1075441412520064"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "40",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "9.8214285714285712E-2"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "3 BANDES",
+    "Posició": "41",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "9.1044776119402981E-2"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "GARCÍA",
+    "Mitjana": "1.64"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.26"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.25"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.0900000000000001"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.99"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "VIVAS",
+    "Mitjana": "0.98"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "0.97"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.78"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "PUIG",
+    "Mitjana": "0.67"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.62"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "MIR",
+    "Mitjana": "0.56999999999999995"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.56000000000000005"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.53"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "J. GRAU",
+    "Mitjana": "0.46"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "TARES",
+    "Mitjana": "0.44"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "JIMENO",
+    "Mitjana": "0.67"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "DONADEU",
+    "Mitjana": "0.61"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "PÉREZ",
+    "Mitjana": "0.48"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "MAGRIÑA",
+    "Mitjana": "0.4"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.35"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.23"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.2"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.07"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "VIVAS",
+    "Mitjana": "1.01"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.87"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.85"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "J. GRAU",
+    "Mitjana": "0.76"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "TALAVERA",
+    "Mitjana": "0.71"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.61"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "RUIZ",
+    "Mitjana": "0.61"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "TARES",
+    "Mitjana": "0.59"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.56000000000000005"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.52"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "TABERNER",
+    "Mitjana": "0.41"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.32"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.43"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.3"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "1.2"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "VIVAS",
+    "Mitjana": "1.03"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "VIDAL",
+    "Mitjana": "0.99"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.96"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.95"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.83"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.76"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "J. GRAU",
+    "Mitjana": "0.75"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.73"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "SERRA",
+    "Mitjana": "0.56000000000000005"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "MIR",
+    "Mitjana": "0.65500000000000003"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.65100000000000002"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.59"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "QUEVEDO",
+    "Mitjana": "0.52"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "R. FINA",
+    "Mitjana": "0.51"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "TARES",
+    "Mitjana": "0.5"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.38"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.28999999999999998"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "1.3"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.1100000000000001"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.06"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "VIVAS",
+    "Mitjana": "1"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.98"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.88600000000000001"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.88200000000000001"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.81"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.78"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.68"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.73"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "REAL",
+    "Mitjana": "0.65"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "RODRÍGUEZ",
+    "Mitjana": "0.61"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "TARES",
+    "Mitjana": "0.54"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.51"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "QUEVEDO",
+    "Mitjana": "0.48"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "ALBARRACIN",
+    "Mitjana": "1.2"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.1399999999999999"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.1299999999999999"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "1.1000000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.02"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "VIDAL",
+    "Mitjana": "1"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "PALAU",
+    "Mitjana": "0.94"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.86"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.86"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.82"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.79"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "SELGAS",
+    "Mitjana": "0.78"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.7"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.6"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "RODRÍGUEZ",
+    "Mitjana": "0.83"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "BARRIENTOS",
+    "Mitjana": "0.81"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "TARES",
+    "Mitjana": "0.75"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.63"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "NOGUER",
+    "Mitjana": "0.61"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "QUEVEDO",
+    "Mitjana": "0.54"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.45"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "MIR",
+    "Mitjana": "0.42"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "MONTERO",
+    "Mitjana": "0.4"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.3"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.23"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.35"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "ALBARRACIN",
+    "Mitjana": "1.33"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "GARCÍA",
+    "Mitjana": "1.32"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.1299999999999999"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "1.1100000000000001"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "ROVIROSA",
+    "Mitjana": "1.08"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "0.95"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "PALAU",
+    "Mitjana": "0.9"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.89"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.87"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.83"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.82"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "BARRIENTOS",
+    "Mitjana": "0.81"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "J. GRAU",
+    "Mitjana": "0.76800000000000002"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "HERNÁNDEZ",
+    "Mitjana": "0.76700000000000002"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "RODRÍGUEZ",
+    "Mitjana": "0.7"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "SELGAS",
+    "Mitjana": "0.64"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "ERRA",
+    "Mitjana": "0.63"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "SOLANS",
+    "Mitjana": "0.62"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.61"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "TARES",
+    "Mitjana": "0.56000000000000005"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "SERRA",
+    "Mitjana": "0.76"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.73"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.65"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "NOGUER",
+    "Mitjana": "0.51"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "MONTERO",
+    "Mitjana": "0.5"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.49099999999999999"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "SUÑE",
+    "Mitjana": "0.49"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.39"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "BANDA",
+    "Posició": "30",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.25"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "ALBARRACIN",
+    "Mitjana": "1.5149999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "DURAN",
+    "Mitjana": "1.472"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.347"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.1140000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "J. SELGA",
+    "Mitjana": "0.98199999999999998"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "VIDAL",
+    "Mitjana": "0.93200000000000005"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "HERNANDEZ",
+    "Mitjana": "0.90800000000000003"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.88800000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.85699999999999998"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "BARRIENTOS",
+    "Mitjana": "0.81799999999999995"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "SELGAS",
+    "Mitjana": "0.67600000000000005"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "GRIÑO",
+    "Mitjana": "0.65700000000000003"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.64500000000000002"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "SERRA",
+    "Mitjana": "0.61799999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "TARES",
+    "Mitjana": "0.57999999999999996"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.56599999999999995"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.53200000000000003"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "MARTÍNEZ",
+    "Mitjana": "0.49199999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "PRAT",
+    "Mitjana": "0.48799999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "ALMIRALL",
+    "Mitjana": "0.48399999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "GÓMEZ",
+    "Mitjana": "0.48"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "MIR",
+    "Mitjana": "0.47299999999999998"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.46800000000000003"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "NOGUER",
+    "Mitjana": "0.46100000000000002"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.46"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.39300000000000002"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "PÉREZ",
+    "Mitjana": "0.33800000000000002"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.316"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.224"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.2390000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.0660000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "1.052"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.97499999999999998"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.94899999999999995"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.93899999999999995"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "C. VIDAL",
+    "Mitjana": "0.92800000000000005"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "M. PALAU",
+    "Mitjana": "0.91200000000000003"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.81499999999999995"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "J. ROVIROSA",
+    "Mitjana": "0.80200000000000005"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.78800000000000003"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.73699999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "R. GRAU",
+    "Mitjana": "0.73599999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.73499999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.73499999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.72799999999999998"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.70099999999999996"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.70099999999999996"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.67400000000000004"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.65600000000000003"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "J. MIR",
+    "Mitjana": "0.64"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "P. SERRA",
+    "Mitjana": "0.629"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.58799999999999997"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "A. PORTA",
+    "Mitjana": "0.58699999999999997"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.56399999999999995"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.55100000000000005"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "M. PRAT",
+    "Mitjana": "0.54800000000000004"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "F. GÓMEZ",
+    "Mitjana": "0.48299999999999998"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "M. ALMIRALL",
+    "Mitjana": "0.47199999999999998"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "30",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.34899999999999998"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "BANDA",
+    "Posició": "31",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.308"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.141"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.075"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.0489999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.0329999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "A. PORTA",
+    "Mitjana": "1.032"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.90300000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.86599999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.81899999999999995"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "R. GRAU",
+    "Mitjana": "0.80900000000000005"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.77500000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "P. SERRA",
+    "Mitjana": "0.75600000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "R. COLOM",
+    "Mitjana": "0.754"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.74099999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.68799999999999994"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.65200000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "E. GIRÓ",
+    "Mitjana": "0.64700000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.61"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "J. GRIÑÓ",
+    "Mitjana": "0.60099999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.57599999999999996"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "F. GÓMEZ",
+    "Mitjana": "0.56100000000000005"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.53600000000000003"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.53"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "M. PRAT",
+    "Mitjana": "0.50600000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.5"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "J. MIR",
+    "Mitjana": "0.46100000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.45400000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.38"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.38"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.318"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "1.6040000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.2869999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.1599999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.0840000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "V. HAMMER",
+    "Mitjana": "1.0509999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "J. COMAS",
+    "Mitjana": "1.034"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.022"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "R. GRAU",
+    "Mitjana": "0.98"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.82399999999999995"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.82199999999999995"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.77700000000000002"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.745"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.72399999999999998"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.72399999999999998"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.71399999999999997"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.69599999999999995"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.66400000000000003"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "P. SERRA",
+    "Mitjana": "0.66100000000000003"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.59499999999999997"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.58699999999999997"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.53500000000000003"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.52800000000000002"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.498"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.46500000000000002"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "M. BRUQUETAS",
+    "Mitjana": "0.46200000000000002"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.46"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.46"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.44900000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.42699999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "30",
+    "Jugador": "P. BALLESTER",
+    "Mitjana": "0.377"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "BANDA",
+    "Posició": "31",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.33600000000000002"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "1.42"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.1399999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "V. HAMMER",
+    "Mitjana": "1.1200000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.103"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.0860000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "E. LUENGO",
+    "Mitjana": "0.86599999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.82499999999999996"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.76"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.754"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.74399999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.72299999999999998"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.70399999999999996"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.70099999999999996"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.7"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.69699999999999995"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "A. CAMPILLO",
+    "Mitjana": "0.65500000000000003"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.61799999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.61399999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.61299999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.61199999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.58299999999999996"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.54200000000000004"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.505"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.48399999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.46800000000000003"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.45900000000000002"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.44900000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "S. MARÍN",
+    "Mitjana": "0.44700000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "M. BRUQUETAS",
+    "Mitjana": "0.434"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "30",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.432"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "31",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.36299999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "32",
+    "Jugador": "J. MONTERO",
+    "Mitjana": "0.33600000000000002"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "33",
+    "Jugador": "P. BALLESTER",
+    "Mitjana": "0.32200000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "34",
+    "Jugador": "J. ARMENGOL",
+    "Mitjana": "0.30399999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "35",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.26600000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "36",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.19400000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "BANDA",
+    "Posició": "37",
+    "Jugador": "R. BURÉS",
+    "Mitjana": "0.19400000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.95099999999999996"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "I. HERNÁNDEZ",
+    "Mitjana": "0.94599999999999995"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.88700000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.88100000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.872"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.86599999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "J. MUÑOZ",
+    "Mitjana": "0.85899999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "R. MORENO",
+    "Mitjana": "0.76600000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "A. TRILLO",
+    "Mitjana": "0.70899999999999996"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.70199999999999996"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.67900000000000005"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.64400000000000002"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "D. CORBALÁN",
+    "Mitjana": "0.57799999999999996"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.55000000000000004"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.53200000000000003"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.50600000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.46300000000000002"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.441"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.44"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.43099999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "A. DEL RIO",
+    "Mitjana": "0.39"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.38500000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.376"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "E. ROYES",
+    "Mitjana": "0.36499999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.34699999999999998"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "A. MORA",
+    "Mitjana": "0.309"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.307"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.30099999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "30",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.28000000000000003"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "31",
+    "Jugador": "J. GRAU",
+    "Mitjana": "0.28000000000000003"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "32",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.27"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "BANDA",
+    "Posició": "33",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.25600000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "1.155"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.127"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.95499999999999996"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.84399999999999997"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.84299999999999997"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "A. MELGAREJO",
+    "Mitjana": "0.83"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.77"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.74399999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "R. MORENO",
+    "Mitjana": "0.71299999999999997"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.70599999999999996"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "A. TRILLO",
+    "Mitjana": "0.67"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.629"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "0.61799999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.61299999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "D. CORBALÁN",
+    "Mitjana": "0.54600000000000004"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.54"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.50900000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.49"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "J. IBÁÑEZ",
+    "Mitjana": "0.47499999999999998"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "F. LEDO",
+    "Mitjana": "0.46"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.45900000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.42899999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.41699999999999998"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.4"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.38300000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.378"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.33400000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "E. ROYES",
+    "Mitjana": "0.32600000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.29299999999999998"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "30",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.27100000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "31",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.26800000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "32",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.26600000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "33",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.36299999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "BANDA",
+    "Posició": "34",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.33600000000000002"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "1.2869999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.1259999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "I. HERNÁNDEZ",
+    "Mitjana": "1.0489999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "1.0049999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.98899999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "A. MELGAREJO",
+    "Mitjana": "0.95499999999999996"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.92900000000000005"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "P. RUIZ",
+    "Mitjana": "0.82399999999999995"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.80300000000000005"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "A. TRILLO",
+    "Mitjana": "0.76900000000000002"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.68200000000000005"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "0.66"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.6"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "J. VEZA",
+    "Mitjana": "0.57899999999999996"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.57399999999999995"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.55800000000000005"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.53300000000000003"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "F. LEDO",
+    "Mitjana": "0.52400000000000002"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.504"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.49399999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.48799999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.45200000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.42199999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.41899999999999998"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "A. MORA",
+    "Mitjana": "0.41299999999999998"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "A. MEDINA",
+    "Mitjana": "0.379"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.34"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.33300000000000002"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.317"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "30",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.313"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "31",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.28799999999999998"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "32",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.28199999999999997"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "BANDA",
+    "Posició": "33",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.255"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "1.318807339449541"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "L. CHUECOS",
+    "Mitjana": "1.134502923976608"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.1298174442190669"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "A. BOIX",
+    "Mitjana": "1.0362595419847329"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "I. HERNÁNDEZ",
+    "Mitjana": "1.007547169811321"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "A. GÓMEZ",
+    "Mitjana": "0.93320610687022898"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.93103448275862066"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.87413793103448278"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "R. MORENO",
+    "Mitjana": "0.84836852207293667"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.81237911025145071"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "0.80073800738007384"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.77333333333333332"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "J.L. ROSERÓ",
+    "Mitjana": "0.74128440366972481"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.7182795698924731"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "J. VEZA",
+    "Mitjana": "0.69807692307692304"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.66666666666666663"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.63617463617463621"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.58935361216730042"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.58502024291497978"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.56302521008403361"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "F. LEDO",
+    "Mitjana": "0.53614457831325302"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.51851851851851849"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "M. GONZALVO",
+    "Mitjana": "0.48440748440748438"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "J. IBÁÑEZ",
+    "Mitjana": "0.46774193548387089"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.45306122448979591"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.44800000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.39959432048681542"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.36105476673427989"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.36"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "30",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.32464929859719438"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "31",
+    "Jugador": "E. ROYES",
+    "Mitjana": "0.32200000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "32",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.27902240325865579"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "33",
+    "Jugador": "A. MEDINA",
+    "Mitjana": "0.442"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "34",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.40442655935613681"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "35",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.25600000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "BANDA",
+    "Posició": "36",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.24"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "1",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.91300000000000003"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "2",
+    "Jugador": "J.M. CAMPOS",
+    "Mitjana": "0.879"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "3",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "1.071"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "4",
+    "Jugador": "L. CHUECOS",
+    "Mitjana": "1.345"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "5",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.873"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "6",
+    "Jugador": "J. DOMINGO",
+    "Mitjana": "0.83499999999999996"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "7",
+    "Jugador": "A. GÓMEZ",
+    "Mitjana": "1.008"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "8",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.002"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "9",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "1.244"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "10",
+    "Jugador": "J. VILA",
+    "Mitjana": "1.0069999999999999"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "11",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "0.73099999999999998"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "12",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.65700000000000003"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "13",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.65500000000000003"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "14",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.57099999999999995"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "15",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.55100000000000005"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "16",
+    "Jugador": "E. LUENGO",
+    "Mitjana": "0.80500000000000005"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "17",
+    "Jugador": "R. MORENO",
+    "Mitjana": "0.80600000000000005"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "18",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.47099999999999997"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "19",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.85299999999999998"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "20",
+    "Jugador": "J.L. ROSERÓ",
+    "Mitjana": "0.81100000000000005"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "21",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.496"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "22",
+    "Jugador": "E. GARCÍA",
+    "Mitjana": "0.55200000000000005"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "23",
+    "Jugador": "J. GÓMEZ",
+    "Mitjana": "0.52900000000000003"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "24",
+    "Jugador": "M. GONZALVO",
+    "Mitjana": "0.438"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "25",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.40500000000000003"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "26",
+    "Jugador": "S. MARÍN",
+    "Mitjana": "0.29099999999999998"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "27",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.38300000000000001"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "28",
+    "Jugador": "J. SÁNCHEZ",
+    "Mitjana": "0.67700000000000005"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "29",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.48699999999999999"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "30",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.39300000000000002"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "31",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.26"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "32",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.36699999999999999"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "33",
+    "Jugador": "A. MEDINA",
+    "Mitjana": "0.43"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "34",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.35499999999999998"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "35",
+    "Jugador": "G. RUIZ",
+    "Mitjana": "0.378"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "36",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.443"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "37",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.30499999999999999"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "BANDA",
+    "Posició": "38",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.23300000000000001"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "1.9650000000000001"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.7729999999999999"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.6719999999999999"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.512"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "1.3839999999999999"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.339"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "J. GRAU",
+    "Mitjana": "1.153"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "PUIG",
+    "Mitjana": "1"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.91200000000000003"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.875"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "TARES",
+    "Mitjana": "0.84899999999999998"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.81599999999999995"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "MIR",
+    "Mitjana": "0.80600000000000005"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "MARTÍNEZ",
+    "Mitjana": "0.80500000000000005"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "DONADEU",
+    "Mitjana": "0.754"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "CASBAS",
+    "Mitjana": "0.72199999999999998"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "MAGRIÑA",
+    "Mitjana": "0.59499999999999997"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "PÉREZ",
+    "Mitjana": "0.54300000000000004"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "BARRIERE",
+    "Mitjana": "0.48099999999999998"
+  },
+  {
+    "Any": "2003",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.47499999999999998"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "RAMÍREZ",
+    "Mitjana": "2.2599999999999998"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "ALCARAZ",
+    "Mitjana": "2.2400000000000002"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.98"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.84"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.83"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.52"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "1.26"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "J. GRAU",
+    "Mitjana": "1.1499999999999999"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "PUIG",
+    "Mitjana": "1.04"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.99"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.85"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.75"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "TARES",
+    "Mitjana": "0.71"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "NOGUER",
+    "Mitjana": "0.68"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "PÉREZ",
+    "Mitjana": "0.67"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "CASBAS",
+    "Mitjana": "0.67"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.63"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "BARRIERE",
+    "Mitjana": "0.55000000000000004"
+  },
+  {
+    "Any": "2004",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.51"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "ALCARAZ",
+    "Mitjana": "2.5299999999999998"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "1.91"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.68"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.61"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.6"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.58"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "VIVAS",
+    "Mitjana": "1.49"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.47"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "X. FINA",
+    "Mitjana": "1.34"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "J. GRAU",
+    "Mitjana": "1.18"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "1.17"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "R. COLOM",
+    "Mitjana": "1.1599999999999999"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "SELGAS",
+    "Mitjana": "1.1299999999999999"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "SERRA",
+    "Mitjana": "1.1299999999999999"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "1.02"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "TARES",
+    "Mitjana": "1.22"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "MIR",
+    "Mitjana": "1.02"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "1.02"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "FARRE",
+    "Mitjana": "0.95"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.84"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "PEÑA",
+    "Mitjana": "0.83"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "SUÑE",
+    "Mitjana": "0.81"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "QUEVEDO",
+    "Mitjana": "0.75"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.47"
+  },
+  {
+    "Any": "2005",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.45"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "2.7"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "ALCARAZ",
+    "Mitjana": "2.4"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.94"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.8"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.78"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.51"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.47"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "R. COLOM",
+    "Mitjana": "1.35"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "X. FINA",
+    "Mitjana": "1.29"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "1.17"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "1.05"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "TARES",
+    "Mitjana": "0.87"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "MIR",
+    "Mitjana": "1.06"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.97"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.86"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "FARRE",
+    "Mitjana": "0.85"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "PEÑA",
+    "Mitjana": "0.84"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "QUEVEDO",
+    "Mitjana": "0.79"
+  },
+  {
+    "Any": "2006",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.5"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "ALCARAZ",
+    "Mitjana": "2.41"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "1.97"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "J. COMAS",
+    "Mitjana": "1.96"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.94"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.91"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.75"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.7"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.46"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "R. COLOM",
+    "Mitjana": "1.4"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "PALAU",
+    "Mitjana": "1.25"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "SELGAS",
+    "Mitjana": "1.17"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "X. FINA",
+    "Mitjana": "1.1100000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "1.0900000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.89"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "BARRIENTOS",
+    "Mitjana": "1.31"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "1.1100000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "RODRÍGUEZ",
+    "Mitjana": "1.1000000000000001"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "1.05"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "REAL",
+    "Mitjana": "1"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "GRIÑO",
+    "Mitjana": "0.99"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.95"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "TARES",
+    "Mitjana": "0.9"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "NOGUER",
+    "Mitjana": "0.88"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.81"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.7"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "QUEVEDO",
+    "Mitjana": "0.66"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "SUÑE",
+    "Mitjana": "0.6"
+  },
+  {
+    "Any": "2007",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.51"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "2.4700000000000002"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "ALCARAZ",
+    "Mitjana": "2.37"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "ALBARRACIN",
+    "Mitjana": "2.1800000000000002"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "2.06"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "J. SELGA",
+    "Mitjana": "2.0099999999999998"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "J. COMAS",
+    "Mitjana": "1.65"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "PALAU",
+    "Mitjana": "1.5"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "P. COMAS",
+    "Mitjana": "1.44"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "1.4"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.32"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "VIVAS",
+    "Mitjana": "1.23"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "J. GRAU",
+    "Mitjana": "1.1599999999999999"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "HERNÁNDEZ",
+    "Mitjana": "1.1399999999999999"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "1.0900000000000001"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "SELGAS",
+    "Mitjana": "1.06"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "BARRIENTOS",
+    "Mitjana": "1.03"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "1.34"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "GRIÑO",
+    "Mitjana": "1.22"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "RODRÍGUEZ",
+    "Mitjana": "1.1000000000000001"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.87"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "SERRA",
+    "Mitjana": "1.01"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "NOGUER",
+    "Mitjana": "0.9"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.87"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.78"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "SUÑE",
+    "Mitjana": "0.76"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "QUEVEDO",
+    "Mitjana": "0.65"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "MONTERO",
+    "Mitjana": "0.64"
+  },
+  {
+    "Any": "2008",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.48"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "DURAN",
+    "Mitjana": "2.3290000000000002"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "ROVIROSA",
+    "Mitjana": "1.85"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.83"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.6779999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "VIDAL",
+    "Mitjana": "1.4490000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "1.4319999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "RODRÍGUEZ",
+    "Mitjana": "1.248"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.177"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "R. COLOM",
+    "Mitjana": "1.151"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "BARRIENTOS",
+    "Mitjana": "1.143"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "PALAU",
+    "Mitjana": "1.129"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "1.1140000000000001"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "TARES",
+    "Mitjana": "1.0509999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "J. GRAU",
+    "Mitjana": "1.014"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "1.01"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "GRIÑO",
+    "Mitjana": "1"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "HERNANDEZ",
+    "Mitjana": "0.96299999999999997"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "SELGAS",
+    "Mitjana": "0.94899999999999995"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.91900000000000004"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "SOLANES",
+    "Mitjana": "0.85399999999999998"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.80300000000000005"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "J. ARMENGOL",
+    "Mitjana": "0.73599999999999999"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.69299999999999995"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "NOGUER",
+    "Mitjana": "0.68700000000000006"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "MONTERO",
+    "Mitjana": "0.68300000000000005"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "MARTÍNEZ",
+    "Mitjana": "0.627"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.623"
+  },
+  {
+    "Any": "2009",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "MARTÍ",
+    "Mitjana": "0.42"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "J. ROVIROSA",
+    "Mitjana": "1.859"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.7709999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.5640000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "R. GRAU",
+    "Mitjana": "1.5589999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.363"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "1.333"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.3009999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "1.3009999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "1.254"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "A. ALUJA",
+    "Mitjana": "1.222"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "P. SERRA",
+    "Mitjana": "1.198"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "M. PALAU",
+    "Mitjana": "1.1970000000000001"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "1.181"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.1739999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "1.105"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "R. COLOM",
+    "Mitjana": "1.085"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "1.0629999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "1.0589999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "1.0309999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "J. GRIÑÓ",
+    "Mitjana": "1"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.86799999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.86399999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.81799999999999995"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "J. MIR",
+    "Mitjana": "0.79600000000000004"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "M. ALMIRALL",
+    "Mitjana": "0.79300000000000004"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.78300000000000003"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "M. PRAT",
+    "Mitjana": "0.77500000000000002"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "M.L. MALLACH",
+    "Mitjana": "0.752"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "29",
+    "Jugador": "M. GIMENO",
+    "Mitjana": "0.73099999999999998"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "30",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.72099999999999997"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "31",
+    "Jugador": "F. GÓMEZ",
+    "Mitjana": "0.69299999999999995"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "32",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.65900000000000003"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "33",
+    "Jugador": "P. BALLESTER",
+    "Mitjana": "0.64900000000000002"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "34",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.42399999999999999"
+  },
+  {
+    "Any": "2011",
+    "Modalitat": "LLIURE",
+    "Posició": "35",
+    "Jugador": "A. MARTÍ",
+    "Mitjana": "0.32200000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.726"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.5149999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.4590000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "1.3220000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "R. COLOM",
+    "Mitjana": "1.2589999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "A. PORTA",
+    "Mitjana": "1.19"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "1.1879999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "1.014"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "E. GIRÓ",
+    "Mitjana": "0.97499999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.96399999999999997"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.94199999999999995"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.90300000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.90300000000000002"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.88400000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.86299999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "P. SERRA",
+    "Mitjana": "0.85299999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "F. GÓMEZ",
+    "Mitjana": "0.82599999999999996"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.76300000000000001"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.73599999999999999"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "M. PRAT",
+    "Mitjana": "0.72199999999999998"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "J. MIR",
+    "Mitjana": "0.70899999999999996"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.61"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.6"
+  },
+  {
+    "Any": "2012",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.252"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "2.0129999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "J. SELGA",
+    "Mitjana": "1.845"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.6990000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.5569999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "J. COMAS",
+    "Mitjana": "1.417"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "1.3660000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "1.296"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "R. GRAU",
+    "Mitjana": "1.1879999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "A. PORTA",
+    "Mitjana": "1.163"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "1.163"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "1.093"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "1.073"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "X. FINA",
+    "Mitjana": "1.034"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "P. SERRA",
+    "Mitjana": "1.01"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.94199999999999995"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.88800000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.86199999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.80600000000000005"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.8"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.79800000000000004"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.75900000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.746"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.74399999999999999"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.69899999999999995"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "M. BRUQUETAS",
+    "Mitjana": "0.56799999999999995"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.55000000000000004"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.54100000000000004"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "J. ARMENGOL",
+    "Mitjana": "0.52300000000000002"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "29",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.497"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "30",
+    "Jugador": "P. BALLESTER",
+    "Mitjana": "0.44600000000000001"
+  },
+  {
+    "Any": "2013",
+    "Modalitat": "LLIURE",
+    "Posició": "31",
+    "Jugador": "J. MONTERO",
+    "Mitjana": "0.443"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "2.125"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "V. HAMMER",
+    "Mitjana": "2.117"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "2.0920000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.7070000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "1.556"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "J. COMAS",
+    "Mitjana": "1.5009999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "E. LUENGO",
+    "Mitjana": "1.415"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "X. FINA",
+    "Mitjana": "1.1890000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "1.1850000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "A. CAMPILLO",
+    "Mitjana": "1.1779999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "1.1599999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "1.1559999999999999"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "1.153"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "E. RODRÍGUEZ",
+    "Mitjana": "1.127"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "1.119"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "1.103"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "1.099"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "1.097"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "J.M. SOMS",
+    "Mitjana": "0.91"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "J. FERNÁNDEZ",
+    "Mitjana": "0.88800000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.77900000000000003"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.754"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.71599999999999997"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.71499999999999997"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.70099999999999996"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "J.M. VIAPLANA",
+    "Mitjana": "0.69199999999999995"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.67600000000000005"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "S. MARÍN",
+    "Mitjana": "0.64800000000000002"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "29",
+    "Jugador": "J. ARMENGOL",
+    "Mitjana": "0.59599999999999997"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "30",
+    "Jugador": "J. MIR",
+    "Mitjana": "0.59299999999999997"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "31",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.51100000000000001"
+  },
+  {
+    "Any": "2014",
+    "Modalitat": "LLIURE",
+    "Posició": "32",
+    "Jugador": "R. BURÉS",
+    "Mitjana": "0.35899999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "1.9410000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "I. HERNÁNDEZ",
+    "Mitjana": "1.5449999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "J. COMAS",
+    "Mitjana": "1.526"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "A. MELGAREJO",
+    "Mitjana": "1.3120000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "1.296"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "A. BOIX",
+    "Mitjana": "1.236"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "1.2270000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "1.224"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "R. MORENO",
+    "Mitjana": "1.1950000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "1.087"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "A. TRILLO",
+    "Mitjana": "1.0189999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.90500000000000003"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "0.90200000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.86899999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.83799999999999997"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.77"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.74299999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.72299999999999998"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.70699999999999996"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "J. IBÁÑEZ",
+    "Mitjana": "0.63900000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.63600000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "D. CORBALÁN",
+    "Mitjana": "0.63200000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "P. FERRÀS",
+    "Mitjana": "0.61499999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "A. DEL RIO",
+    "Mitjana": "0.61399999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.60299999999999998"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "J. CABRÉ",
+    "Mitjana": "0.59"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "F. LEDO",
+    "Mitjana": "0.57799999999999996"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.53700000000000003"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "29",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.51800000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "30",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.503"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "31",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.498"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "32",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.48499999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "33",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.443"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "34",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.42299999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "35",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.4"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "36",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.38900000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "LLIURE",
+    "Posició": "37",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.35199999999999998"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "2.0070000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "1.6479999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "1.37"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "P. RUIZ",
+    "Mitjana": "1.349"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "R. MORENO",
+    "Mitjana": "1.2709999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "J. COMAS",
+    "Mitjana": "1.2450000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "1.2390000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "1.214"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "A. BOIX",
+    "Mitjana": "1.19"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "A. TRILLO",
+    "Mitjana": "1.1000000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.98199999999999998"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.94299999999999995"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "0.93100000000000005"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.88800000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.79600000000000004"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.78"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.77900000000000003"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.77500000000000002"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "F. LEDO",
+    "Mitjana": "0.752"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.73699999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.68799999999999994"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.68100000000000005"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.67500000000000004"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "J. ROYES",
+    "Mitjana": "0.65700000000000003"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "J. IBÁÑEZ",
+    "Mitjana": "0.64700000000000002"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.61899999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.58699999999999997"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "A. MEDINA",
+    "Mitjana": "0.57799999999999996"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "29",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.56399999999999995"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "30",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.49199999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "31",
+    "Jugador": "E. ROYES",
+    "Mitjana": "0.49"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "32",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.47899999999999998"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "33",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.432"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "34",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.42499999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "LLIURE",
+    "Posició": "35",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.35499999999999998"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "2.2850000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "1.897"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "I. HERNÁNDEZ",
+    "Mitjana": "1.5469999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "J. COMAS",
+    "Mitjana": "1.4339999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "R. MORENO",
+    "Mitjana": "1.3939999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "1.359"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "A. BOIX",
+    "Mitjana": "1.262"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "A. GÓMEZ",
+    "Mitjana": "1.167"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "1.077"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "1.0289999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "J.L. ROSERÓ",
+    "Mitjana": "0.95899999999999996"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.875"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.79800000000000004"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.78200000000000003"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.77500000000000002"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.76100000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.71399999999999997"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "J. IBÁÑEZ",
+    "Mitjana": "0.69299999999999995"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "A. MEDINA",
+    "Mitjana": "0.63800000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.627"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.60199999999999998"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.57599999999999996"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.56899999999999995"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.54800000000000004"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "A. FERNÁNDEZ",
+    "Mitjana": "0.496"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.48799999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.47099999999999997"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.46899999999999997"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "29",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.44700000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "30",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.39800000000000002"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "31",
+    "Jugador": "E. ROYES",
+    "Mitjana": "0.39600000000000002"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "LLIURE",
+    "Posició": "32",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.32500000000000001"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "1",
+    "Jugador": "L. CHUECOS",
+    "Mitjana": "1.907590759075908"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "2",
+    "Jugador": "A. BERMEJO",
+    "Mitjana": "1.8191489361702129"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "3",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "1.7362318840579709"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "4",
+    "Jugador": "J. COMAS",
+    "Mitjana": "1.5171339563862929"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "5",
+    "Jugador": "J. VILA",
+    "Mitjana": "1.3693181818181821"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "6",
+    "Jugador": "A. GÓMEZ",
+    "Mitjana": "1.3442136498516319"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "7",
+    "Jugador": "J.M. CAMPOS",
+    "Mitjana": "1.323809523809524"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "8",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "1.288095238095238"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "9",
+    "Jugador": "R. MORENO",
+    "Mitjana": "1.194379391100703"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "10",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "1.177033492822966"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "11",
+    "Jugador": "E. LUENGO",
+    "Mitjana": "1.1526881720430111"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "12",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "1.06029106029106"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "13",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.92768079800498748"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "14",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.92601431980906923"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "15",
+    "Jugador": "J.L. ROSERÓ",
+    "Mitjana": "0.92074592074592077"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "16",
+    "Jugador": "A. FUENTES",
+    "Mitjana": "0.84082397003745324"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "17",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.79400749063670417"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "18",
+    "Jugador": "J. IBÁÑEZ",
+    "Mitjana": "0.77229601518026569"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "19",
+    "Jugador": "J. SÁNCHEZ",
+    "Mitjana": "0.7609108159392789"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "20",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.75506445672191524"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "21",
+    "Jugador": "A. MEDINA",
+    "Mitjana": "0.73643410852713176"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "22",
+    "Jugador": "E. GARCÍA",
+    "Mitjana": "0.73482428115015974"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "23",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.71224489795918366"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "24",
+    "Jugador": "M. GONZALVO",
+    "Mitjana": "0.70436187399030692"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "25",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.7032755298651252"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "26",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.68204283360790774"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "27",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.68097014925373134"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "28",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.67632850241545894"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "29",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.6741573033707865"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "30",
+    "Jugador": "J. GÓMEZ",
+    "Mitjana": "0.66771159874608155"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "31",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.62180579216354348"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "32",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.60917721518987344"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "33",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.59966499162479059"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "34",
+    "Jugador": "P. FERRÀS",
+    "Mitjana": "0.58557046979865768"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "35",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.53355704697986572"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "36",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.52307692307692311"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "37",
+    "Jugador": "S. MARÍN",
+    "Mitjana": "0.50363636363636366"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "38",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.49"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "39",
+    "Jugador": "A. MORA",
+    "Mitjana": "0.46790540540540537"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "40",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.41666666666666669"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "41",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.41442953020134232"
+  },
+  {
+    "Any": "2025",
+    "Modalitat": "LLIURE",
+    "Posició": "42",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.37454545454545463"
+  }
+]

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,6 +6,7 @@ self.addEventListener("install", event => {
         "./index.html",
         "./style.css",
         "./main.js",
+        "./ranquing.json",
         "./icon-192.png",
         "./icon-512.png"
       ]);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,23 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+  background: #f3f3f3;
+}
+button {
+  padding: 0.5rem 1rem;
+  margin: 0.25rem;
+  font-size: 1rem;
+}
+#content {
+  margin-top: 1rem;
+}
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+th, td {
+  border: 1px solid #999;
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+}


### PR DESCRIPTION
## Resum
- afegeix `ranquing.json` generat a partir de l'arxiu Excel
- nou fitxer `style.css`
- actualitza `index.html` amb botó per mostrar el rànquing
- funcionalitat a `main.js` per carregar i mostrar el rànquing
- el `service-worker.js` ara cacheja el nou JSON

## Testing
- `npm test` *(falla: package.json inexistent)*

------
https://chatgpt.com/codex/tasks/task_e_6887681d0b38832ea27e1fecde35d7db