### PR TITLE
Update ranking filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
   <h1>Billar Foment Martinenc</h1>
   <div id="menu">
     <button id="btn-ranking">Veure rànquing</button>
-    <select id="year-select"></select>
-    <div id="modalitat-buttons" class="button-group">
+    <select id="year-select" style="display:none"></select>
+    <div id="modalitat-buttons" class="button-group" style="display:none">
       <button data-mod="3 BANDES">3 Bandes</button>
       <button data-mod="BANDA">Banda</button>
       <button data-mod="LLIURE">Lliure</button>

--- a/main.js
+++ b/main.js
@@ -23,7 +23,6 @@ function inicialitza() {
         .sort((a, b) => a - b);
       anySeleccionat = anys[anys.length - 1];
       preparaSelectors();
-      mostraRanquing();
     })
     .catch(err => {
       console.error('Error carregant el ranquing', err);
@@ -64,7 +63,7 @@ function mostraRanquing() {
   cont.innerHTML = '';
   const taula = document.createElement('table');
   const cap = document.createElement('tr');
-  ['Any', 'Modalitat', 'Posició', 'Jugador', 'Mitjana'].forEach(t => {
+  ['Posició', 'Jugador', 'Mitjana'].forEach(t => {
     const th = document.createElement('th');
     th.textContent = t;
     cap.appendChild(th);
@@ -76,7 +75,7 @@ function mostraRanquing() {
       reg.Modalitat === modalitatSeleccionada)
     .forEach(reg => {
       const tr = document.createElement('tr');
-      ['Any', 'Modalitat', 'Posició', 'Jugador', 'Mitjana'].forEach(clau => {
+      ['Posició', 'Jugador', 'Mitjana'].forEach(clau => {
         const td = document.createElement('td');
         let valor = reg[clau];
         if (clau === 'Mitjana') {
@@ -90,6 +89,10 @@ function mostraRanquing() {
   cont.appendChild(taula);
 }
 
-document.getElementById('btn-ranking').addEventListener('click', mostraRanquing);
+document.getElementById('btn-ranking').addEventListener('click', () => {
+  document.getElementById('year-select').style.display = 'inline-block';
+  document.getElementById('modalitat-buttons').style.display = 'inline-block';
+  mostraRanquing();
+});
 
 inicialitza();

--- a/style.css
+++ b/style.css
@@ -29,10 +29,12 @@ button {
 }
 table {
   border-collapse: collapse;
-  width: 100%;
+  width: max-content;
+  max-width: 100%;
 }
 th, td {
   border: 1px solid #999;
   padding: 0.25rem 0.5rem;
   text-align: left;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- hide year dropdown and modality buttons until the ranking is requested
- show only position, player and average in the table
- make table width adapt to content

## Testing
- `node -c main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68876e39e2b4832e8decf2f7959a85e6