### PR TITLE
Adjust ranking UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,13 @@
   <h1>Billar Foment Martinenc</h1>
   <div id="menu">
     <button id="btn-ranking">Veure rànquing</button>
-    <select id="year-select" style="display:none"></select>
-    <div id="modalitat-buttons" class="button-group" style="display:none">
-      <button data-mod="3 BANDES">3 Bandes</button>
-      <button data-mod="BANDA">Banda</button>
-      <button data-mod="LLIURE">Lliure</button>
+    <div id="filters-row" style="display:none">
+      <select id="year-select"></select>
+      <div id="modalitat-buttons" class="button-group">
+        <button data-mod="3 BANDES">3 Bandes</button>
+        <button data-mod="BANDA">Banda</button>
+        <button data-mod="LLIURE">Lliure</button>
+      </div>
     </div>
     <!-- aquí es poden afegir més botons en el futur -->
   </div>

--- a/main.js
+++ b/main.js
@@ -90,8 +90,7 @@ function mostraRanquing() {
 }
 
 document.getElementById('btn-ranking').addEventListener('click', () => {
-  document.getElementById('year-select').style.display = 'inline-block';
-  document.getElementById('modalitat-buttons').style.display = 'inline-block';
+  document.getElementById('filters-row').style.display = 'flex';
   mostraRanquing();
 });
 

--- a/style.css
+++ b/style.css
@@ -24,6 +24,11 @@ button {
   margin: 0.25rem;
   font-size: 1rem;
 }
+#filters-row {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+}
 #content {
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- move the year dropdown and modality buttons to a new row below the ranking button
- style the new filter row
- update event logic to reveal the row

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68876f650668832e8bfb35fdc1bf6800