### PR TITLE
Add player evolution chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,11 @@
     <!-- aquí es poden afegir més botons en el futur -->
   </div>
   <div id="content"></div>
+  <div id="player-chart" style="display:none">
+    <button id="close-chart">Tancar</button>
+    <canvas id="chart-canvas" width="400" height="300"></canvas>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -82,6 +82,13 @@ function mostraRanquing() {
           valor = Number.parseFloat(reg[clau]).toFixed(3);
         }
         td.textContent = valor;
+        if (clau === 'Jugador') {
+          td.classList.add('jugador-cell');
+          td.style.cursor = 'pointer';
+          td.addEventListener('click', () => {
+            mostraEvolucioJugador(reg['Jugador'], modalitatSeleccionada);
+          });
+        }
         tr.appendChild(td);
       });
       taula.appendChild(tr);
@@ -89,9 +96,44 @@ function mostraRanquing() {
   cont.appendChild(taula);
 }
 
+function mostraEvolucioJugador(jugador, modalitat) {
+  const dades = ranquing
+    .filter(r => r.Jugador === jugador && r.Modalitat === modalitat)
+    .map(r => ({ any: parseInt(r.Any, 10), mitjana: parseFloat(r.Mitjana) }))
+    .sort((a, b) => a.any - b.any);
+  const labels = dades.map(d => d.any);
+  const values = dades.map(d => Number.parseFloat(d.mitjana).toFixed(3));
+  const canvas = document.getElementById('chart-canvas');
+  if (window.playerChart) {
+    window.playerChart.destroy();
+  }
+  window.playerChart = new Chart(canvas, {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: [{
+        label: jugador + ' - ' + modalitat,
+        data: values,
+        fill: false,
+        borderColor: 'blue'
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: false }
+      }
+    }
+  });
+  document.getElementById('player-chart').style.display = 'flex';
+}
+
 document.getElementById('btn-ranking').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'flex';
   mostraRanquing();
+});
+
+document.getElementById('close-chart').addEventListener('click', () => {
+  document.getElementById('player-chart').style.display = 'none';
 });
 
 inicialitza();

--- a/style.css
+++ b/style.css
@@ -43,3 +43,27 @@ th, td {
   text-align: left;
   white-space: nowrap;
 }
+
+#player-chart {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#player-chart canvas {
+  background: #fff;
+  max-width: 90%;
+}
+
+#player-chart button {
+  align-self: flex-end;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add chart container and Chart.js to visualize player evolution
- overlay styling for the chart
- add logic in JS to show evolution when clicking a player's name

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6887802f7e4c832e9d268624f47d0bc1