### PR TITLE
Set dark theme

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "SocialsFM",
   "start_url": ".",
   "display": "standalone",
-  "background_color": "#ffffff",
+  "background_color": "#000000",
   "theme_color": "#000000",
   "icons": [
     {

--- a/style.css
+++ b/style.css
@@ -2,12 +2,16 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 1rem;
-  background: #f3f3f3;
+  background: #000;
+  color: #fff;
 }
 button {
   padding: 0.5rem 1rem;
   margin: 0.25rem;
   font-size: 1rem;
+  background: #444;
+  color: #fff;
+  border: 1px solid #666;
 }
 
 .button-group {
@@ -15,7 +19,7 @@ button {
 }
 
 .button-group button.selected {
-  background: #333;
+  background: #666;
   color: #fff;
 }
 
@@ -23,6 +27,9 @@ button {
   padding: 0.5rem;
   margin: 0.25rem;
   font-size: 1rem;
+  background: #444;
+  color: #fff;
+  border: 1px solid #666;
 }
 #filters-row {
   margin-top: 0.5rem;
@@ -38,7 +45,7 @@ table {
   max-width: 100%;
 }
 th, td {
-  border: 1px solid #999;
+  border: 1px solid #666;
   padding: 0.25rem 0.5rem;
   text-align: left;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- switch body background to black
- update text and button colors for contrast
- align manifest background color with dark theme

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887805c3df8832ea5a4f3f826997290