### PR TITLE
Adjust ranking menu layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -81,6 +81,7 @@ button:active {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  width: 100%;
 }
 
 #content {


### PR DESCRIPTION
## Summary
- ensure filter buttons appear below the "Veure rànquing" button by making the filter row occupy full width

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6887a7898cf0832eb70fa00ae41c6b65