### PR TITLE
Add chart for player evolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,11 @@
     </div>
     <div id="content"></div>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <div id="player-chart" style="display:none;flex-direction:column;align-items:flex-end;margin-top:1rem;">
+    <button id="close-chart">Tanca</button>
+    <canvas id="chart-canvas"></canvas>
+  </div>
   <script src="main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -95,6 +95,9 @@ function mostraRanquing() {
       tr.appendChild(td);
 
     });
+    tr.addEventListener('click', () => {
+      mostraEvolucioJugador(reg.Jugador, modalitatSeleccionada);
+    });
     taula.appendChild(tr);
   });
   cont.appendChild(taula);

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,6 +6,7 @@ self.addEventListener("install", event => {
         "./index.html",
         "./style.css",
         "./main.js",
+        "https://cdn.jsdelivr.net/npm/chart.js",
         "./ranquing.json",
         "./icons/icon-192.png",
         "./icons/icon-512.png"

--- a/style.css
+++ b/style.css
@@ -118,3 +118,18 @@ th {
 tr:nth-child(even) {
   background: #f5f5f5;
 }
+
+#player-chart {
+  display: none;
+  flex-direction: column;
+  align-items: flex-end;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-top: 1rem;
+}
+
+#player-chart canvas {
+  max-width: 100%;
+}


### PR DESCRIPTION
## Summary
- integrate Chart.js and player chart container
- show player's ranking evolution on row click
- style the chart container
- cache Chart.js in service worker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887ac9932a0832eb1b32804331977a4