### PR TITLE
Actualització rànquing des de Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # Foment
-Foment
+Aplicació per visualitzar el rànquing de billar.
+
+## Com executar
+
+```bash
+python3 server.py
+```
+
+Aquesta ordre arrenca un petit servidor web a `http://localhost:8000`.
+Des de la mateixa aplicació es pot actualitzar `ranquing.json` a
+partir de `Ranquing.xlsx` amb el botó **Actualitza rànquing**.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <h1>Billar Foment Martinenc</h1>
     <div id="menu">
     <button id="btn-ranking">Veure rànquing</button>
+    <button id="btn-update">Actualitza rànquing</button>
     <div id="filters-row" style="display:none">
       <select id="year-select"></select>
       <div id="modalitat-buttons" class="button-group">

--- a/main.js
+++ b/main.js
@@ -136,6 +136,21 @@ document.getElementById('btn-ranking').addEventListener('click', () => {
   mostraRanquing();
 });
 
+document.getElementById('btn-update').addEventListener('click', () => {
+  fetch('/update-ranking')
+    .then(res => {
+      if (!res.ok) throw new Error('Error actualitzant el r\xe0nquing');
+      return res.json();
+    })
+    .then(() => {
+      inicialitza();
+    })
+    .catch(err => {
+      console.error(err);
+      alert('No s\'ha pogut actualitzar el r\xe0nquing');
+    });
+});
+
 document.getElementById('close-chart').addEventListener('click', () => {
   document.getElementById('player-chart').style.display = 'none';
 });

--- a/ranquing.json
+++ b/ranquing.json
@@ -8762,5 +8762,2245 @@
     "Posició": "42",
     "Jugador": "J. ORTIZ",
     "Mitjana": "0.37454545454545463"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.46300000000000002"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.38300000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.34300000000000003"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "R. GRAU",
+    "Mitjana": "0.34"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.32600000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.32400000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.32300000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "E. RODRÍGUEZ",
+    "Mitjana": "0.315"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.30499999999999999"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.28799999999999998"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.28499999999999998"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.27600000000000002"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.27400000000000002"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.26300000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "J.M. VAL",
+    "Mitjana": "0.25900000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.251"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.224"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.223"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.219"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "A. POMETTI",
+    "Mitjana": "0.19700000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.187"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "A. CAMPILLO",
+    "Mitjana": "0.184"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "S. BARRIS",
+    "Mitjana": "0.17599999999999999"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.16800000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.16400000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "A. DEL RIO",
+    "Mitjana": "0.156"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.15"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.15"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "S. MARÍN",
+    "Mitjana": "0.14000000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.13700000000000001"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "M. BRUQUETAS",
+    "Mitjana": "0.112"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.09"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "R. BURÉS",
+    "Mitjana": "6.9000000000000006E-2"
+  },
+  {
+    "Any": "2016",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "0.08"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.39300000000000002"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.38800000000000001"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.38"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.35"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.33400000000000002"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.314"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.31"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.309"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.29499999999999998"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.28999999999999998"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "J.M. VAL",
+    "Mitjana": "0.28899999999999998"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.27700000000000002"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.27300000000000002"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "J. SELGAS",
+    "Mitjana": "0.27300000000000002"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.26600000000000001"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.255"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "P. SOLERGIBERT",
+    "Mitjana": "0.24399999999999999"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "G. GIMÉNEZ",
+    "Mitjana": "0.23899999999999999"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.23799999999999999"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.23499999999999999"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "J. LAHOZ",
+    "Mitjana": "0.224"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.22"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "D. CORBALÁN",
+    "Mitjana": "0.21099999999999999"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.19"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "A. POMETTI",
+    "Mitjana": "0.188"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.182"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "F. TARÉS",
+    "Mitjana": "0.159"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.155"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "J. GÓMEZ",
+    "Mitjana": "0.15"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "A. DEL RÍO",
+    "Mitjana": "0.13400000000000001"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.126"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "P. FERRÁS",
+    "Mitjana": "0.122"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "ESCODA",
+    "Mitjana": "0.11799999999999999"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "J.M. VALLÉS",
+    "Mitjana": "9.1999999999999998E-2"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.09"
+  },
+  {
+    "Any": "2017",
+    "Modalitat": "3 BANDES",
+    "Posició": "36",
+    "Jugador": "R. BURÉS",
+    "Mitjana": "0.05"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.441"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.38500000000000001"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.378"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.35799999999999998"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.313"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "JOAN RODRÍGUEZ",
+    "Mitjana": "0.36"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.30099999999999999"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "E.RODRÍGUEZ",
+    "Mitjana": "0.28999999999999998"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "M.PAMPLONA",
+    "Mitjana": "0.28699999999999998"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "G. RASTROLLO",
+    "Mitjana": "0.27"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.26900000000000002"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.26700000000000002"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.26100000000000001"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.249"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.248"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J.Mª VAL",
+    "Mitjana": "0.246"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "E. LAHOZ",
+    "Mitjana": "0.245"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "D. CORBALÁN",
+    "Mitjana": "0.24399999999999999"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.23300000000000001"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.22800000000000001"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "G.GIMÉNEZ",
+    "Mitjana": "0.21199999999999999"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "F. TORRECILLAS",
+    "Mitjana": "0.19400000000000001"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.19400000000000001"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.187"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "J.Mª SOMS",
+    "Mitjana": "0.185"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.182"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "A. DEL RÍO",
+    "Mitjana": "0.18"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "P. SERRA",
+    "Mitjana": "0.17399999999999999"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "A.TRILLO",
+    "Mitjana": "0.17100000000000001"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "A.POMETTI",
+    "Mitjana": "0.151"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "A. DÍEZ",
+    "Mitjana": "0.14599999999999999"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "P. FERRÁS",
+    "Mitjana": "0.14599999999999999"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "J. GÓMEZ",
+    "Mitjana": "0.13700000000000001"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "R.POLLS",
+    "Mitjana": "0.11799999999999999"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.108"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "36",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.1"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "37",
+    "Jugador": "M.QUEROL",
+    "Mitjana": "7.8E-2"
+  },
+  {
+    "Any": "2018",
+    "Modalitat": "3 BANDES",
+    "Posició": "38",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "7.2999999999999995E-2"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.441"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.38500000000000001"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.378"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.35799999999999998"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.313"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "JOAN RODRÍGUEZ",
+    "Mitjana": "0.36"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.30099999999999999"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "E.RODRÍGUEZ",
+    "Mitjana": "0.28999999999999998"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "M.PAMPLONA",
+    "Mitjana": "0.28699999999999998"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "G. RASTROLLO",
+    "Mitjana": "0.27"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "J.M. RODRÍGUEZ",
+    "Mitjana": "0.26900000000000002"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "F. BARCIA",
+    "Mitjana": "0.26700000000000002"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.26100000000000001"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.249"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.248"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J.Mª VAL",
+    "Mitjana": "0.246"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "E. LAHOZ",
+    "Mitjana": "0.245"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "D. CORBALÁN",
+    "Mitjana": "0.24399999999999999"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.23300000000000001"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.22800000000000001"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "G.GIMÉNEZ",
+    "Mitjana": "0.21199999999999999"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "F. TORRECILLAS",
+    "Mitjana": "0.19400000000000001"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.19400000000000001"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.187"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "J.Mª SOMS",
+    "Mitjana": "0.185"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.182"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "A. DEL RÍO",
+    "Mitjana": "0.18"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "P. SERRA",
+    "Mitjana": "0.17399999999999999"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "A.TRILLO",
+    "Mitjana": "0.17100000000000001"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "A.POMETTI",
+    "Mitjana": "0.151"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "A. DÍEZ",
+    "Mitjana": "0.14599999999999999"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "P. FERRÁS",
+    "Mitjana": "0.14599999999999999"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "J. GÓMEZ",
+    "Mitjana": "0.13700000000000001"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "R.POLLS",
+    "Mitjana": "0.11799999999999999"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "A. MARTÍNEZ",
+    "Mitjana": "0.108"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "36",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.1"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "37",
+    "Jugador": "M.QUEROL",
+    "Mitjana": "7.8E-2"
+  },
+  {
+    "Any": "2019",
+    "Modalitat": "3 BANDES",
+    "Posició": "38",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "7.2999999999999995E-2"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.443"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.39"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "JOAN RODRÍGUEZ",
+    "Mitjana": "0.375"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.35699999999999998"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.34899999999999998"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "A.BOIX",
+    "Mitjana": "0.33900000000000002"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "X. FINA",
+    "Mitjana": "0.33100000000000002"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.33100000000000002"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.32400000000000001"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "IG. HERNÁNDEZ",
+    "Mitjana": "0.309"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.30499999999999999"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "P. SOLERGIBERT",
+    "Mitjana": "0.30099999999999999"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "J.Mª VAL",
+    "Mitjana": "0.28799999999999998"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.28599999999999998"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "J. GELABERT",
+    "Mitjana": "0.27800000000000002"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "M. ALVAREZ",
+    "Mitjana": "0.27500000000000002"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.27"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "D. CORBALÁN",
+    "Mitjana": "0.23699999999999999"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "A.TRILLO",
+    "Mitjana": "0.22"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "A. CASTILLO",
+    "Mitjana": "0.21"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "G.GIMÉNEZ",
+    "Mitjana": "0.20200000000000001"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.2"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.19700000000000001"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.19600000000000001"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "J.Mª SOMS",
+    "Mitjana": "0.186"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.182"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "P. FERRÁS",
+    "Mitjana": "0.18"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "M. EBRÍ",
+    "Mitjana": "0.17699999999999999"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.16900000000000001"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.121"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.12"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.115"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "9.1999999999999998E-2"
+  },
+  {
+    "Any": "2020",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "6.9000000000000006E-2"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.39400000000000002"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.37"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.34399999999999997"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.33900000000000002"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.33400000000000002"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.32900000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "LL. GONZÁLEZ",
+    "Mitjana": "0.32300000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "D. CORBALÁN",
+    "Mitjana": "0.28000000000000003"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.26800000000000002"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "A. TRILLO",
+    "Mitjana": "0.249"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.247"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.22900000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.20499999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "J.M. GIBERNAU",
+    "Mitjana": "0.19900000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.19"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "A. DEL RÍO",
+    "Mitjana": "0.187"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.17799999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "R. MORENO",
+    "Mitjana": "0.17199999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.154"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.14399999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.14000000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.13900000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "J.L. SAUCEDO",
+    "Mitjana": "0.13100000000000001"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.12"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.11799999999999999"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.111"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "E. LLORENTE",
+    "Mitjana": "0.106"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "9.6000000000000002E-2"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "E. ROYES",
+    "Mitjana": "8.6999999999999994E-2"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "8.3000000000000004E-2"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "8.1000000000000003E-2"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "7.4999999999999997E-2"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "6.3E-2"
+  },
+  {
+    "Any": "2021",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.39800000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.52400000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "J. MUÑOZ",
+    "Mitjana": "0.46"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "L. GONZÁLEZ",
+    "Mitjana": "0.33800000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.33400000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.32300000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.315"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.28299999999999997"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "A. TRILLO",
+    "Mitjana": "0.28199999999999997"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.27500000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.26900000000000002"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "J. MELGAREJO",
+    "Mitjana": "0.26500000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "P. ALVAREZ",
+    "Mitjana": "0.25"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "D. CORBALÁN",
+    "Mitjana": "0.24099999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "R. MORENO",
+    "Mitjana": "0.23"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.2"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.193"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "J. VEZA",
+    "Mitjana": "0.193"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.183"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "V. INOCENTES",
+    "Mitjana": "0.18"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.17799999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "P. FERRÀS",
+    "Mitjana": "0.16700000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.16200000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.161"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "F. LEDO",
+    "Mitjana": "0.15"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "J. IBAÑEZ",
+    "Mitjana": "0.14399999999999999"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.13700000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.13500000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.13400000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "A. MORA",
+    "Mitjana": "0.121"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.12"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.11700000000000001"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.115"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.115"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "9.9000000000000005E-2"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "9.6000000000000002E-2"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "36",
+    "Jugador": "F. ROYES",
+    "Mitjana": "8.7999999999999995E-2"
+  },
+  {
+    "Any": "2022",
+    "Modalitat": "3 BANDES",
+    "Posició": "37",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "8.3000000000000004E-2"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.48599999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.41099999999999998"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.33"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "A. MELGAREJO",
+    "Mitjana": "0.316"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.30099999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "M. ALVAREZ",
+    "Mitjana": "0.28399999999999997"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.27500000000000002"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "M. PAMPLONA",
+    "Mitjana": "0.26100000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.26"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "I. LÓPEZ",
+    "Mitjana": "0.24299999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.22600000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "R. MORENO",
+    "Mitjana": "0.23300000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "0.224"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.218"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.20899999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.20899999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.186"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "J. VEZA",
+    "Mitjana": "0.17599999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.17599999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "J. GIBERNAU",
+    "Mitjana": "0.17"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.16700000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "J. IBAÑEZ",
+    "Mitjana": "0.156"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.155"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.14899999999999999"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.14000000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "P. FERRÀS",
+    "Mitjana": "0.13700000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.12"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "0.11700000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.11600000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.108"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.108"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "0.107"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.10100000000000001"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "34",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "9.7000000000000003E-2"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "35",
+    "Jugador": "E. ROYES",
+    "Mitjana": "8.8999999999999996E-2"
+  },
+  {
+    "Any": "2023",
+    "Modalitat": "3 BANDES",
+    "Posició": "36",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "6.3E-2"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "1",
+    "Jugador": "A. GÓMEZ",
+    "Mitjana": "0.47499999999999998"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "2",
+    "Jugador": "E. LEÓN",
+    "Mitjana": "0.42399999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "3",
+    "Jugador": "J.F. SANTOS",
+    "Mitjana": "0.42"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "4",
+    "Jugador": "J.M. CAMPOS",
+    "Mitjana": "0.38300000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "5",
+    "Jugador": "A. BOIX",
+    "Mitjana": "0.34899999999999998"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "6",
+    "Jugador": "J. RODRÍGUEZ",
+    "Mitjana": "0.34200000000000003"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "7",
+    "Jugador": "R. CERVANTES",
+    "Mitjana": "0.33900000000000002"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "8",
+    "Jugador": "A. MELGAREJO",
+    "Mitjana": "0.30299999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "9",
+    "Jugador": "J. COMAS",
+    "Mitjana": "0.28299999999999997"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "10",
+    "Jugador": "P. ÁLVAREZ",
+    "Mitjana": "0.27100000000000002"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "11",
+    "Jugador": "M. SÁNCHEZ",
+    "Mitjana": "0.248"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "12",
+    "Jugador": "R. MERCADER",
+    "Mitjana": "0.22700000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "13",
+    "Jugador": "R. MORENO",
+    "Mitjana": "0.22600000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "14",
+    "Jugador": "P. CASANOVA",
+    "Mitjana": "0.221"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "15",
+    "Jugador": "E. DÍAZ",
+    "Mitjana": "0.21299999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "16",
+    "Jugador": "J. FITÓ",
+    "Mitjana": "0.20200000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "17",
+    "Jugador": "J. VEZA",
+    "Mitjana": "0.20200000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "18",
+    "Jugador": "J.A. SAUCEDO",
+    "Mitjana": "0.19"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "19",
+    "Jugador": "J. HERNÁNDEZ",
+    "Mitjana": "0.188"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "20",
+    "Jugador": "R. SOTO",
+    "Mitjana": "0.186"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "21",
+    "Jugador": "A. MEDINA",
+    "Mitjana": "0.17599999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "22",
+    "Jugador": "E. CURCÓ",
+    "Mitjana": "0.17499999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "23",
+    "Jugador": "R. POLLS",
+    "Mitjana": "0.17199999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "24",
+    "Jugador": "J.L. ARROYO",
+    "Mitjana": "0.16"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "25",
+    "Jugador": "M. QUEROL",
+    "Mitjana": "0.14099999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "26",
+    "Jugador": "R. JARQUE",
+    "Mitjana": "0.14099999999999999"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "27",
+    "Jugador": "E. MILLÁN",
+    "Mitjana": "0.13500000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "28",
+    "Jugador": "J. CARRASCO",
+    "Mitjana": "0.122"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "29",
+    "Jugador": "M. MANZANO",
+    "Mitjana": "0.11700000000000001"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "30",
+    "Jugador": "J.M. CASAMOR",
+    "Mitjana": "0.108"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "31",
+    "Jugador": "F. VERDUGO",
+    "Mitjana": "9.9000000000000005E-2"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "32",
+    "Jugador": "J. ORTIZ",
+    "Mitjana": "9.0999999999999998E-2"
+  },
+  {
+    "Any": "2024",
+    "Modalitat": "3 BANDES",
+    "Posició": "33",
+    "Jugador": "J. VALLÉS",
+    "Mitjana": "8.7999999999999995E-2"
   }
 ]

--- a/server.py
+++ b/server.py
@@ -1,0 +1,29 @@
+import http.server
+import socketserver
+import subprocess
+import os
+from pathlib import Path
+
+PORT = 8000
+WEB_DIR = Path(__file__).resolve().parent
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/update-ranking':
+            try:
+                subprocess.run(['python3', 'update_ranquing.py'], check=True)
+                self.send_response(200)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(b'{"status": "ok"}')
+            except subprocess.CalledProcessError:
+                self.send_response(500)
+                self.end_headers()
+            return
+        return http.server.SimpleHTTPRequestHandler.do_GET(self)
+
+if __name__ == '__main__':
+    os.chdir(WEB_DIR)
+    with socketserver.TCPServer(('', PORT), Handler) as httpd:
+        print(f'Serving on http://localhost:{PORT}')
+        httpd.serve_forever()

--- a/update_ranquing.py
+++ b/update_ranquing.py
@@ -1,0 +1,52 @@
+import zipfile
+import xml.etree.ElementTree as ET
+import json
+from pathlib import Path
+
+XLSX_FILE = Path('Ranquing.xlsx')
+JSON_FILE = Path('ranquing.json')
+
+NS = {'a': 'http://schemas.openxmlformats.org/spreadsheetml/2006/main'}
+
+def load_shared_strings(z):
+    data = z.read('xl/sharedStrings.xml')
+    tree = ET.fromstring(data)
+    strings = []
+    for t in tree.findall('.//a:t', NS):
+        strings.append(t.text or '')
+    return strings
+
+def cell_value(cell, strings):
+    v = cell.find('a:v', NS)
+    if v is None:
+        return ''
+    val = v.text or ''
+    if cell.get('t') == 's':
+        idx = int(val)
+        return strings[idx]
+    return val
+
+def update():
+    with zipfile.ZipFile(XLSX_FILE) as z:
+        strings = load_shared_strings(z)
+        sheet_xml = z.read('xl/worksheets/sheet1.xml')
+    sheet = ET.fromstring(sheet_xml)
+    sheet_data = sheet.find('a:sheetData', NS)
+    rows = []
+    for row in sheet_data.findall('a:row', NS):
+        r_index = int(row.get('r'))
+        if r_index == 1:
+            continue  # header
+        cells = {c.get('r')[0]: c for c in row.findall('a:c', NS)}
+        record = {
+            'Any': cell_value(cells.get('A', ET.Element('c')), strings),
+            'Modalitat': cell_value(cells.get('B', ET.Element('c')), strings),
+            'Posició': cell_value(cells.get('C', ET.Element('c')), strings),
+            'Jugador': cell_value(cells.get('D', ET.Element('c')), strings),
+            'Mitjana': cell_value(cells.get('E', ET.Element('c')), strings),
+        }
+        rows.append(record)
+    JSON_FILE.write_text(json.dumps(rows, ensure_ascii=False, indent=2))
+
+if __name__ == '__main__':
+    update()


### PR DESCRIPTION
## Resum
- afegeix script `update_ranquing.py` per generar `ranquing.json` a partir de `Ranquing.xlsx`
- servidor simple `server.py` amb endpoint `/update-ranking`
- botó `Actualitza rànquing` a `index.html`
- codi client en `main.js` per cridar l'endpoint
- documentació bàsica a `README.md`

## Testing
- `python3 update_ranquing.py`
- `python3 server.py & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6887abc60064832e8aefe775a42e95eb