### PR TITLE
Add clickable player evolution chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,11 @@
     </div>
     <div id="content"></div>
   </div>
+  <div id="player-chart" style="display:none;flex-direction:column;align-items:flex-end;margin-top:1rem;">
+    <button id="close-chart">Tanca</button>
+    <h3 id="chart-title" style="align-self:center;margin:0.5rem 0;"></h3>
+    <canvas id="chart-canvas"></canvas>
+  </div>
   <script src="main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -92,6 +92,13 @@ function mostraRanquing() {
         valor = reg[clau];
       }
       td.textContent = valor;
+      if (clau === 'Jugador') {
+        td.classList.add('player-cell');
+        td.addEventListener('click', e => {
+          e.stopPropagation();
+          mostraEvolucioJugador(reg.Jugador, modalitatSeleccionada);
+        });
+      }
       tr.appendChild(td);
 
     });
@@ -100,34 +107,66 @@ function mostraRanquing() {
   cont.appendChild(taula);
 }
 
+function drawLineChart(canvas, labels, data, label) {
+  const ctx = canvas.getContext('2d');
+  const width = canvas.width;
+  const height = canvas.height;
+  ctx.clearRect(0, 0, width, height);
+  const pad = 40;
+  const w = width - pad * 2;
+  const h = height - pad * 2;
+  const minY = Math.min(...data);
+  const maxY = Math.max(...data);
+  const range = maxY - minY || 1;
+
+  ctx.strokeStyle = '#000';
+  ctx.beginPath();
+  ctx.moveTo(pad, pad);
+  ctx.lineTo(pad, pad + h);
+  ctx.lineTo(pad + w, pad + h);
+  ctx.stroke();
+
+  ctx.strokeStyle = 'blue';
+  ctx.beginPath();
+  data.forEach((v, i) => {
+    const x = pad + (w * i) / (data.length - 1);
+    const y = pad + h - ((v - minY) / range) * h;
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+
+  ctx.fillStyle = '#000';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  labels.forEach((lab, i) => {
+    const x = pad + (w * i) / (labels.length - 1);
+    ctx.fillText(lab, x, pad + h + 5);
+  });
+
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'middle';
+  const steps = 4;
+  for (let i = 0; i <= steps; i++) {
+    const val = minY + (range * i) / steps;
+    const y = pad + h - (h * i) / steps;
+    ctx.fillText(val.toFixed(2), pad - 5, y);
+  }
+}
+
 function mostraEvolucioJugador(jugador, modalitat) {
   const dades = ranquing
     .filter(r => r.Jugador === jugador && r.Modalitat === modalitat)
     .map(r => ({ any: parseInt(r.Any, 10), mitjana: parseFloat(r.Mitjana) }))
     .sort((a, b) => a.any - b.any);
   const labels = dades.map(d => d.any);
-  const values = dades.map(d => Number.parseFloat(d.mitjana).toFixed(3));
+  const values = dades.map(d => Number.parseFloat(d.mitjana));
   const canvas = document.getElementById('chart-canvas');
-  if (window.playerChart) {
-    window.playerChart.destroy();
+  if (!canvas.width) {
+    canvas.width = 400;
+    canvas.height = 300;
   }
-  window.playerChart = new Chart(canvas, {
-    type: 'line',
-    data: {
-      labels: labels,
-      datasets: [{
-        label: jugador + ' - ' + modalitat,
-        data: values,
-        fill: false,
-        borderColor: 'blue'
-      }]
-    },
-    options: {
-      scales: {
-        y: { beginAtZero: false }
-      }
-    }
-  });
+  document.getElementById('chart-title').textContent = jugador + ' - ' + modalitat;
+  drawLineChart(canvas, labels, values, jugador + ' - ' + modalitat);
   document.getElementById('player-chart').style.display = 'flex';
 }
 
@@ -138,6 +177,7 @@ document.getElementById('btn-ranking').addEventListener('click', () => {
 
 document.getElementById('close-chart').addEventListener('click', () => {
   document.getElementById('player-chart').style.display = 'none';
+  document.getElementById('chart-title').textContent = '';
 });
 
 inicialitza();

--- a/style.css
+++ b/style.css
@@ -118,3 +118,29 @@ th {
 tr:nth-child(even) {
   background: #f5f5f5;
 }
+
+#player-chart {
+  display: none;
+  flex-direction: column;
+  align-items: flex-end;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-top: 1rem;
+}
+
+#player-chart h3 {
+  align-self: center;
+  margin: 0.5rem 0;
+}
+
+#player-chart canvas {
+  max-width: 100%;
+}
+
+.player-cell {
+  cursor: pointer;
+  color: var(--primary-dark);
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- make player names clickable to open chart
- style the clickable cells and show player name above the chart

## Testing
- `node -c main.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887ac9932a0832eb1b32804331977a4