### PR TITLE
Add chart title when viewing player history

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 
   <div id="player-chart" style="display:none;flex-direction:column;align-items:flex-end;margin-top:1rem;">
     <button id="close-chart">Tanca</button>
+    <h3 id="chart-title" style="align-self:center;margin:0.5rem 0;"></h3>
 
     <canvas id="chart-canvas"></canvas>
   </div>

--- a/main.js
+++ b/main.js
@@ -169,6 +169,11 @@ function mostraEvolucioJugador(jugador, modalitat) {
     canvas.height = 300;
   }
 
+  const title = document.getElementById('chart-title');
+  if (title) {
+    title.textContent = jugador + ' - ' + modalitat;
+  }
+
   drawLineChart(canvas, labels, values, jugador + ' - ' + modalitat);
   document.getElementById('player-chart').style.display = 'flex';
 }
@@ -195,7 +200,10 @@ document.getElementById('btn-update').addEventListener('click', () => {
 
 document.getElementById('close-chart').addEventListener('click', () => {
   document.getElementById('player-chart').style.display = 'none';
-  document.getElementById('chart-title').textContent = '';
+  const title = document.getElementById('chart-title');
+  if (title) {
+    title.textContent = '';
+  }
 });
 
 inicialitza();

--- a/style.css
+++ b/style.css
@@ -130,8 +130,19 @@ tr:nth-child(even) {
   margin-top: 1rem;
 }
 
+#player-chart h3 {
+  align-self: center;
+  margin: 0.5rem 0;
+}
+
 
 #player-chart canvas {
   max-width: 100%;
+}
+
+.player-cell {
+  cursor: pointer;
+  color: var(--primary-dark);
+  text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
- add missing heading for player chart in `index.html`
- style player cell and chart title
- populate chart title when showing history
- avoid error if heading is absent when closing chart

## Testing
- `python3 -m py_compile server.py update_ranquing.py`
- `node -e "const fs=require('fs');new Function(fs.readFileSync('main.js','utf8'));" && echo 'JS OK'`

------
https://chatgpt.com/codex/tasks/task_e_6887b283334c832e9e14a257558e1aa1