### PR TITLE
Show full member names in ranking

### DIFF
--- a/main.js
+++ b/main.js
@@ -90,21 +90,21 @@ function mostraRanquing() {
       } else if (clau === 'Mitjana') {
         valor = Number.parseFloat(reg[clau]).toFixed(3);
       } else {
-        valor = reg[clau];
+        valor = clau === 'Jugador' ? reg.NomComplet : reg[clau];
       }
       td.textContent = valor;
       if (clau === 'Jugador') {
         td.classList.add('player-cell');
         td.addEventListener('click', e => {
           e.stopPropagation();
-          mostraEvolucioJugador(reg.Jugador, modalitatSeleccionada);
+          mostraEvolucioJugador(reg.Jugador, reg.NomComplet, modalitatSeleccionada);
         });
       }
       tr.appendChild(td);
 
     });
     tr.addEventListener('click', () => {
-      mostraEvolucioJugador(reg.Jugador, modalitatSeleccionada);
+      mostraEvolucioJugador(reg.Jugador, reg.NomComplet, modalitatSeleccionada);
     });
     taula.appendChild(tr);
   });
@@ -112,7 +112,7 @@ function mostraRanquing() {
 }
 
 
-function mostraEvolucioJugador(jugador, modalitat) {
+function mostraEvolucioJugador(jugador, nom, modalitat) {
   const dades = ranquing
     .filter(r => r.Jugador === jugador && r.Modalitat === modalitat)
     .map(r => ({ any: parseInt(r.Any, 10), mitjana: parseFloat(r.Mitjana) }))
@@ -127,7 +127,7 @@ function mostraEvolucioJugador(jugador, modalitat) {
 
   const title = document.getElementById('chart-title');
   if (title) {
-    title.textContent = jugador + ' - ' + modalitat;
+    title.textContent = nom + ' - ' + modalitat;
   }
 
   const ctx = canvas.getContext('2d');
@@ -139,7 +139,7 @@ function mostraEvolucioJugador(jugador, modalitat) {
     data: {
       labels,
       datasets: [{
-        label: jugador + ' - ' + modalitat,
+        label: nom + ' - ' + modalitat,
         data: values,
         borderColor: 'blue',
         backgroundColor: 'rgba(0, 0, 255, 0.1)',

--- a/ranquing.json
+++ b/ranquing.json
@@ -4,11003 +4,18863 @@
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "GARCÍA",
-    "Mitjana": "0.54900000000000004"
+    "Mitjana": "0.54900000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "GARCÍA"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.45600000000000002"
+    "Mitjana": "0.45600000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.40100000000000002"
+    "Mitjana": "0.40100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.38800000000000001"
+    "Mitjana": "0.38800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "VIVAS",
-    "Mitjana": "0.38800000000000001"
+    "Mitjana": "0.38800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "DONADEU",
-    "Mitjana": "0.26700000000000002"
+    "Mitjana": "0.26700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "DONADEU"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.23300000000000001"
+    "Mitjana": "0.23300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.22"
+    "Mitjana": "0.22",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "PUIG",
-    "Mitjana": "0.2"
+    "Mitjana": "0.2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PUIG"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.19800000000000001"
+    "Mitjana": "0.19800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "TARES",
-    "Mitjana": "0.183"
+    "Mitjana": "0.183",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "TABERNER",
-    "Mitjana": "0.183"
+    "Mitjana": "0.183",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TABERNER"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "MIR",
-    "Mitjana": "0.159"
+    "Mitjana": "0.159",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "MAGRIÑA",
-    "Mitjana": "0.153"
+    "Mitjana": "0.153",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MAGRIÑA"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.14799999999999999"
+    "Mitjana": "0.14799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2003",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "MARTÍ",
-    "Mitjana": "9.5000000000000001E-2"
+    "Mitjana": "9.5000000000000001E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.495"
+    "Mitjana": "0.495",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.41499999999999998"
+    "Mitjana": "0.41499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "VIVAS",
-    "Mitjana": "0.36799999999999999"
+    "Mitjana": "0.36799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.308"
+    "Mitjana": "0.308",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "RUIZ",
-    "Mitjana": "0.23200000000000001"
+    "Mitjana": "0.23200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RUIZ"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "J. GRAU",
-    "Mitjana": "0.22800000000000001"
+    "Mitjana": "0.22800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "PUIG",
-    "Mitjana": "0.20699999999999999"
+    "Mitjana": "0.20699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PUIG"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.19500000000000001"
+    "Mitjana": "0.19500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.17599999999999999"
+    "Mitjana": "0.17599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "TARES",
-    "Mitjana": "0.14000000000000001"
+    "Mitjana": "0.14000000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2004",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.12"
+    "Mitjana": "0.12",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.42399999999999999"
+    "Mitjana": "0.42399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.38800000000000001"
+    "Mitjana": "0.38800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "VIVAS",
-    "Mitjana": "0.32"
+    "Mitjana": "0.32",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "X. FINA",
-    "Mitjana": "0.31900000000000001"
+    "Mitjana": "0.31900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.28299999999999997"
+    "Mitjana": "0.28299999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.26900000000000002"
+    "Mitjana": "0.26900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.24299999999999999"
+    "Mitjana": "0.24299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.23599999999999999"
+    "Mitjana": "0.23599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.22900000000000001"
+    "Mitjana": "0.22900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "PUIG",
-    "Mitjana": "0.22800000000000001"
+    "Mitjana": "0.22800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PUIG"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "0.22"
+    "Mitjana": "0.22",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.17299999999999999"
+    "Mitjana": "0.17299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "RUIZ",
-    "Mitjana": "0.11600000000000001"
+    "Mitjana": "0.11600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RUIZ"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "TARES",
-    "Mitjana": "0.218"
+    "Mitjana": "0.218",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "MIR",
-    "Mitjana": "0.214"
+    "Mitjana": "0.214",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.186"
+    "Mitjana": "0.186",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "TABERNER",
-    "Mitjana": "0.17399999999999999"
+    "Mitjana": "0.17399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TABERNER"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.12"
+    "Mitjana": "0.12",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "R. FINA",
-    "Mitjana": "8.2000000000000003E-2"
+    "Mitjana": "8.2000000000000003E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. FINA"
   },
   {
     "Any": "2005",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "MARTÍ",
-    "Mitjana": "7.0000000000000007E-2"
+    "Mitjana": "7.0000000000000007E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.33600000000000002"
+    "Mitjana": "0.33600000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "X. FINA",
-    "Mitjana": "0.33300000000000002"
+    "Mitjana": "0.33300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.33100000000000002"
+    "Mitjana": "0.33100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "0.32900000000000001"
+    "Mitjana": "0.32900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.32500000000000001"
+    "Mitjana": "0.32500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "PUIG",
-    "Mitjana": "0.27400000000000002"
+    "Mitjana": "0.27400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PUIG"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.27100000000000002"
+    "Mitjana": "0.27100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "J. GRAU",
-    "Mitjana": "0.26400000000000001"
+    "Mitjana": "0.26400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.25900000000000001"
+    "Mitjana": "0.25900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.23699999999999999"
+    "Mitjana": "0.23699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.219"
+    "Mitjana": "0.219",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "REAL",
-    "Mitjana": "0.19600000000000001"
+    "Mitjana": "0.19600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "REAL"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "RUIZ",
-    "Mitjana": "0.23499999999999999"
+    "Mitjana": "0.23499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RUIZ"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "TARES",
-    "Mitjana": "0.21299999999999999"
+    "Mitjana": "0.21299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "MIR",
-    "Mitjana": "0.17699999999999999"
+    "Mitjana": "0.17699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.17399999999999999"
+    "Mitjana": "0.17399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "SERRA",
-    "Mitjana": "0.16700000000000001"
+    "Mitjana": "0.16700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SERRA"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.14899999999999999"
+    "Mitjana": "0.14899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.12"
+    "Mitjana": "0.12",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2006",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "QUEVEDO",
-    "Mitjana": "0.11600000000000001"
+    "Mitjana": "0.11600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "QUEVEDO"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.45300000000000001"
+    "Mitjana": "0.45300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.39400000000000002"
+    "Mitjana": "0.39400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.379"
+    "Mitjana": "0.379",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.33500000000000002"
+    "Mitjana": "0.33500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.313"
+    "Mitjana": "0.313",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "PALAU",
-    "Mitjana": "0.29799999999999999"
+    "Mitjana": "0.29799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PALAU"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "SELGAS",
-    "Mitjana": "0.28699999999999998"
+    "Mitjana": "0.28699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "0.27700000000000002"
+    "Mitjana": "0.27700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "X. FINA",
-    "Mitjana": "0.253"
+    "Mitjana": "0.253",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "PUIG",
-    "Mitjana": "0.254"
+    "Mitjana": "0.254",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PUIG"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.24199999999999999"
+    "Mitjana": "0.24199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.20399999999999999"
+    "Mitjana": "0.20399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.182"
+    "Mitjana": "0.182",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.16900000000000001"
+    "Mitjana": "0.16900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.20799999999999999"
+    "Mitjana": "0.20799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "REAL",
-    "Mitjana": "0.20799999999999999"
+    "Mitjana": "0.20799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "REAL"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "BARRIENTOS",
-    "Mitjana": "0.19900000000000001"
+    "Mitjana": "0.19900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIENTOS"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.13600000000000001"
+    "Mitjana": "0.13600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "QUEVEDO",
-    "Mitjana": "0.1"
+    "Mitjana": "0.1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "QUEVEDO"
   },
   {
     "Any": "2007",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "MARTÍ",
-    "Mitjana": "7.3999999999999996E-2"
+    "Mitjana": "7.3999999999999996E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "ALBARRACIN",
-    "Mitjana": "0.53"
+    "Mitjana": "0.53",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALBARRACIN"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "DURAN",
-    "Mitjana": "0.5"
+    "Mitjana": "0.5",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "DURAN"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.45"
+    "Mitjana": "0.45",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.41"
+    "Mitjana": "0.41",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.4"
+    "Mitjana": "0.4",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "VIDAL",
-    "Mitjana": "0.37"
+    "Mitjana": "0.37",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.32"
+    "Mitjana": "0.32",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "ROVIROSA",
-    "Mitjana": "0.3"
+    "Mitjana": "0.3",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ROVIROSA"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "J. GRAU",
-    "Mitjana": "0.28000000000000003"
+    "Mitjana": "0.28000000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "VIVAS",
-    "Mitjana": "0.27400000000000002"
+    "Mitjana": "0.27400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.27179999999999999"
+    "Mitjana": "0.27179999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.27129999999999999"
+    "Mitjana": "0.27129999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "PALAU",
-    "Mitjana": "0.26"
+    "Mitjana": "0.26",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PALAU"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.24"
+    "Mitjana": "0.24",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "SELGAS",
-    "Mitjana": "0.14000000000000001"
+    "Mitjana": "0.14000000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "TARES",
-    "Mitjana": "0.22"
+    "Mitjana": "0.22",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "HERNANDEZ",
-    "Mitjana": "0.2"
+    "Mitjana": "0.2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "HERNANDEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.18"
+    "Mitjana": "0.18",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "BARRIENTOS",
-    "Mitjana": "0.17"
+    "Mitjana": "0.17",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIENTOS"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.14499999999999999"
+    "Mitjana": "0.14499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.14399999999999999"
+    "Mitjana": "0.14399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2008",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.11"
+    "Mitjana": "0.11",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.55000000000000004"
+    "Mitjana": "0.55000000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "DURAN",
-    "Mitjana": "0.46"
+    "Mitjana": "0.46",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "DURAN"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.38700000000000001"
+    "Mitjana": "0.38700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.38200000000000001"
+    "Mitjana": "0.38200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.377"
+    "Mitjana": "0.377",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "PALAU",
-    "Mitjana": "0.33600000000000002"
+    "Mitjana": "0.33600000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PALAU"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.30199999999999999"
+    "Mitjana": "0.30199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.29199999999999998"
+    "Mitjana": "0.29199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "J. GRAU",
-    "Mitjana": "0.28100000000000003"
+    "Mitjana": "0.28100000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "VIVAS",
-    "Mitjana": "0.28000000000000003"
+    "Mitjana": "0.28000000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "ROVIROSA",
-    "Mitjana": "0.27100000000000002"
+    "Mitjana": "0.27100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ROVIROSA"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.26100000000000001"
+    "Mitjana": "0.26100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.253"
+    "Mitjana": "0.253",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "SERRA",
-    "Mitjana": "0.252"
+    "Mitjana": "0.252",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SERRA"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "HERNANDEZ",
-    "Mitjana": "0.23100000000000001"
+    "Mitjana": "0.23100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "HERNANDEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "SELGAS",
-    "Mitjana": "0.22800000000000001"
+    "Mitjana": "0.22800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "RODRÍGUEZ",
-    "Mitjana": "0.22700000000000001"
+    "Mitjana": "0.22700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RODRÍGUEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "SOLANES",
-    "Mitjana": "0.22500000000000001"
+    "Mitjana": "0.22500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SOLANES"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.22500000000000001"
+    "Mitjana": "0.22500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.21"
+    "Mitjana": "0.21",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.188"
+    "Mitjana": "0.188",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "BARRIENTOS",
-    "Mitjana": "0.16800000000000001"
+    "Mitjana": "0.16800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIENTOS"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "TARES",
-    "Mitjana": "0.16400000000000001"
+    "Mitjana": "0.16400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.159"
+    "Mitjana": "0.159",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "GÓMEZ",
-    "Mitjana": "0.153"
+    "Mitjana": "0.153",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "GÓMEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.14399999999999999"
+    "Mitjana": "0.14399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "MARTÍNEZ",
-    "Mitjana": "0.14399999999999999"
+    "Mitjana": "0.14399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍNEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.13700000000000001"
+    "Mitjana": "0.13700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "MIR",
-    "Mitjana": "0.13700000000000001"
+    "Mitjana": "0.13700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.13500000000000001"
+    "Mitjana": "0.13500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "PRAT",
-    "Mitjana": "0.13200000000000001"
+    "Mitjana": "0.13200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PRAT"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "J. ARMENGOL",
-    "Mitjana": "0.112"
+    "Mitjana": "0.112",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ARMENGOL"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "NOGUER",
-    "Mitjana": "8.5000000000000006E-2"
+    "Mitjana": "8.5000000000000006E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "NOGUER"
   },
   {
     "Any": "2009",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "MARTÍ",
-    "Mitjana": "7.0000000000000007E-2"
+    "Mitjana": "7.0000000000000007E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "R. GRAU",
-    "Mitjana": "0.47199999999999998"
+    "Mitjana": "0.47199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.443"
+    "Mitjana": "0.443",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.41499999999999998"
+    "Mitjana": "0.41499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.40600000000000003"
+    "Mitjana": "0.40600000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.38400000000000001"
+    "Mitjana": "0.38400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.35199999999999998"
+    "Mitjana": "0.35199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "A. ALUJA",
-    "Mitjana": "0.35"
+    "Mitjana": "0.35",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. ALUJA"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.35"
+    "Mitjana": "0.35",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.33600000000000002"
+    "Mitjana": "0.33600000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.318"
+    "Mitjana": "0.318",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "M. PALAU",
-    "Mitjana": "0.315"
+    "Mitjana": "0.315",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PALAU"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "P. SERRA",
-    "Mitjana": "0.28199999999999997"
+    "Mitjana": "0.28199999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.25900000000000001"
+    "Mitjana": "0.25900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.25800000000000001"
+    "Mitjana": "0.25800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.24399999999999999"
+    "Mitjana": "0.24399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "X. FINA",
-    "Mitjana": "0.23400000000000001"
+    "Mitjana": "0.23400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.23300000000000001"
+    "Mitjana": "0.23300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.22900000000000001"
+    "Mitjana": "0.22900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.22700000000000001"
+    "Mitjana": "0.22700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.215"
+    "Mitjana": "0.215",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "F. GÓMEZ",
-    "Mitjana": "0.21"
+    "Mitjana": "0.21",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. GÓMEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.187"
+    "Mitjana": "0.187",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.182"
+    "Mitjana": "0.182",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.16700000000000001"
+    "Mitjana": "0.16700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.16400000000000001"
+    "Mitjana": "0.16400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "J. MIR",
-    "Mitjana": "0.16300000000000001"
+    "Mitjana": "0.16300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MIR"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "J. SANZ",
-    "Mitjana": "0.14399999999999999"
+    "Mitjana": "0.14399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SANZ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "P. BALLESTER",
-    "Mitjana": "0.13700000000000001"
+    "Mitjana": "0.13700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. BALLESTER"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.129"
+    "Mitjana": "0.129",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.11899999999999999"
+    "Mitjana": "0.11899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.11700000000000001"
+    "Mitjana": "0.11700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2011",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "M. PRAT",
-    "Mitjana": "0.11"
+    "Mitjana": "0.11",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PRAT"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.45800000000000002"
+    "Mitjana": "0.45800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.42599999999999999"
+    "Mitjana": "0.42599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.38400000000000001"
+    "Mitjana": "0.38400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.33700000000000002"
+    "Mitjana": "0.33700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "E. RODRÍGUEZ",
-    "Mitjana": "0.34699999999999998"
+    "Mitjana": "0.34699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. RODRÍGUEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.34100000000000003"
+    "Mitjana": "0.34100000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.33800000000000002"
+    "Mitjana": "0.33800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "A. PORTA",
-    "Mitjana": "0.33700000000000002"
+    "Mitjana": "0.33700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. PORTA"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.317"
+    "Mitjana": "0.317",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "R. GRAU",
-    "Mitjana": "0.30399999999999999"
+    "Mitjana": "0.30399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "0.29399999999999998"
+    "Mitjana": "0.29399999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.28999999999999998"
+    "Mitjana": "0.28999999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.28799999999999998"
+    "Mitjana": "0.28799999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.28699999999999998"
+    "Mitjana": "0.28699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.28599999999999998"
+    "Mitjana": "0.28599999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.27200000000000002"
+    "Mitjana": "0.27200000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.249"
+    "Mitjana": "0.249",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.247"
+    "Mitjana": "0.247",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.24199999999999999"
+    "Mitjana": "0.24199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "P. SERRA",
-    "Mitjana": "0.23899999999999999"
+    "Mitjana": "0.23899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.23100000000000001"
+    "Mitjana": "0.23100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.22900000000000001"
+    "Mitjana": "0.22900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.20799999999999999"
+    "Mitjana": "0.20799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.19600000000000001"
+    "Mitjana": "0.19600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "C. GIRÓ",
-    "Mitjana": "0.188"
+    "Mitjana": "0.188",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "C. GIRÓ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.185"
+    "Mitjana": "0.185",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.17599999999999999"
+    "Mitjana": "0.17599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "F. GÓMEZ",
-    "Mitjana": "0.17499999999999999"
+    "Mitjana": "0.17499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. GÓMEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "M. BRUQUETAS",
-    "Mitjana": "0.17"
+    "Mitjana": "0.17",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. BRUQUETAS"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.155"
+    "Mitjana": "0.155",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "M. PRAT",
-    "Mitjana": "0.14499999999999999"
+    "Mitjana": "0.14499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PRAT"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.13900000000000001"
+    "Mitjana": "0.13900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "P. BALLESTER",
-    "Mitjana": "0.13700000000000001"
+    "Mitjana": "0.13700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. BALLESTER"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.122"
+    "Mitjana": "0.122",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2012",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.104"
+    "Mitjana": "0.104",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.443"
+    "Mitjana": "0.443",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.42499999999999999"
+    "Mitjana": "0.42499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "V. HAMMER",
-    "Mitjana": "0.39900000000000002"
+    "Mitjana": "0.39900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. HAMMER"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.38100000000000001"
+    "Mitjana": "0.38100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.35499999999999998"
+    "Mitjana": "0.35499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.33700000000000002"
+    "Mitjana": "0.33700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.32300000000000001"
+    "Mitjana": "0.32300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "R. GRAU",
-    "Mitjana": "0.30199999999999999"
+    "Mitjana": "0.30199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.28699999999999998"
+    "Mitjana": "0.28699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.28499999999999998"
+    "Mitjana": "0.28499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.27400000000000002"
+    "Mitjana": "0.27400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.26800000000000002"
+    "Mitjana": "0.26800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.22900000000000001"
+    "Mitjana": "0.22900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "X. FINA",
-    "Mitjana": "0.221"
+    "Mitjana": "0.221",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.214"
+    "Mitjana": "0.214",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.214"
+    "Mitjana": "0.214",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.214"
+    "Mitjana": "0.214",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "P. SERRA",
-    "Mitjana": "0.21199999999999999"
+    "Mitjana": "0.21199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.20599999999999999"
+    "Mitjana": "0.20599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "M. BRUQUETAS",
-    "Mitjana": "0.20100000000000001"
+    "Mitjana": "0.20100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. BRUQUETAS"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.19900000000000001"
+    "Mitjana": "0.19900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.193"
+    "Mitjana": "0.193",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.189"
+    "Mitjana": "0.189",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.188"
+    "Mitjana": "0.188",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.17599999999999999"
+    "Mitjana": "0.17599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.17"
+    "Mitjana": "0.17",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.155"
+    "Mitjana": "0.155",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "P. BALLESTER",
-    "Mitjana": "0.14799999999999999"
+    "Mitjana": "0.14799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. BALLESTER"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.14399999999999999"
+    "Mitjana": "0.14399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.13800000000000001"
+    "Mitjana": "0.13800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.13500000000000001"
+    "Mitjana": "0.13500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.13100000000000001"
+    "Mitjana": "0.13100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "J. ARMENGOL",
-    "Mitjana": "0.13"
+    "Mitjana": "0.13",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ARMENGOL"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.108"
+    "Mitjana": "0.108",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2013",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "M. QUEROL",
-    "Mitjana": "5.8999999999999997E-2"
+    "Mitjana": "5.8999999999999997E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.45800000000000002"
+    "Mitjana": "0.45800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.40200000000000002"
+    "Mitjana": "0.40200000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.38800000000000001"
+    "Mitjana": "0.38800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.375"
+    "Mitjana": "0.375",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.35599999999999998"
+    "Mitjana": "0.35599999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.35099999999999998"
+    "Mitjana": "0.35099999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.33300000000000002"
+    "Mitjana": "0.33300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "R. GRAU",
-    "Mitjana": "0.32600000000000001"
+    "Mitjana": "0.32600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "V. HAMMER",
-    "Mitjana": "0.32300000000000001"
+    "Mitjana": "0.32300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. HAMMER"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "X. FINA",
-    "Mitjana": "0.32100000000000001"
+    "Mitjana": "0.32100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.307"
+    "Mitjana": "0.307",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.30399999999999999"
+    "Mitjana": "0.30399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.29599999999999999"
+    "Mitjana": "0.29599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "A. PORTA",
-    "Mitjana": "0.28799999999999998"
+    "Mitjana": "0.28799999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. PORTA"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "E. LUENGO",
-    "Mitjana": "0.28199999999999997"
+    "Mitjana": "0.28199999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LUENGO"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "E. RODRÍGUEZ",
-    "Mitjana": "0.26200000000000001"
+    "Mitjana": "0.26200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. RODRÍGUEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.25600000000000001"
+    "Mitjana": "0.25600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.254"
+    "Mitjana": "0.254",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.252"
+    "Mitjana": "0.252",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.247"
+    "Mitjana": "0.247",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.22600000000000001"
+    "Mitjana": "0.22600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.222"
+    "Mitjana": "0.222",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.221"
+    "Mitjana": "0.221",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.217"
+    "Mitjana": "0.217",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.21199999999999999"
+    "Mitjana": "0.21199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.21199999999999999"
+    "Mitjana": "0.21199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.20899999999999999"
+    "Mitjana": "0.20899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.193"
+    "Mitjana": "0.193",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.17599999999999999"
+    "Mitjana": "0.17599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.158"
+    "Mitjana": "0.158",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "P. BALLESTER",
-    "Mitjana": "0.14899999999999999"
+    "Mitjana": "0.14899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. BALLESTER"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.14699999999999999"
+    "Mitjana": "0.14699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.13400000000000001"
+    "Mitjana": "0.13400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.128"
+    "Mitjana": "0.128",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "J. ARMENGOL",
-    "Mitjana": "0.123"
+    "Mitjana": "0.123",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ARMENGOL"
   },
   {
     "Any": "2014",
     "Modalitat": "3 BANDES",
     "Posició": "36",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "4.1000000000000002E-2"
+    "Mitjana": "4.1000000000000002E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.439"
+    "Mitjana": "0.439",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.41699999999999998"
+    "Mitjana": "0.41699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.38"
+    "Mitjana": "0.38",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.36299999999999999"
+    "Mitjana": "0.36299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "E. RODRÍGUEZ",
-    "Mitjana": "0.34799999999999998"
+    "Mitjana": "0.34799999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. RODRÍGUEZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.33100000000000002"
+    "Mitjana": "0.33100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.32200000000000001"
+    "Mitjana": "0.32200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "V. HAMMER",
-    "Mitjana": "0.318"
+    "Mitjana": "0.318",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. HAMMER"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.313"
+    "Mitjana": "0.313",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.309"
+    "Mitjana": "0.309",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "X. FINA",
-    "Mitjana": "0.29599999999999999"
+    "Mitjana": "0.29599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.29299999999999998"
+    "Mitjana": "0.29299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.28199999999999997"
+    "Mitjana": "0.28199999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "A. PORTA",
-    "Mitjana": "0.27900000000000003"
+    "Mitjana": "0.27900000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. PORTA"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.27"
+    "Mitjana": "0.27",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.26"
+    "Mitjana": "0.26",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "R. GRAU",
-    "Mitjana": "0.26"
+    "Mitjana": "0.26",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.24399999999999999"
+    "Mitjana": "0.24399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.24399999999999999"
+    "Mitjana": "0.24399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "A. CAMPILLO",
-    "Mitjana": "0.23699999999999999"
+    "Mitjana": "0.23699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CAMPILLO"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.22500000000000001"
+    "Mitjana": "0.22500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.223"
+    "Mitjana": "0.223",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.216"
+    "Mitjana": "0.216",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.214"
+    "Mitjana": "0.214",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.20799999999999999"
+    "Mitjana": "0.20799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.20499999999999999"
+    "Mitjana": "0.20499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.20200000000000001"
+    "Mitjana": "0.20200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.20200000000000001"
+    "Mitjana": "0.20200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.2"
+    "Mitjana": "0.2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "S. MARÍN",
-    "Mitjana": "0.16600000000000001"
+    "Mitjana": "0.16600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. MARÍN"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "M. BRUQUETAS",
-    "Mitjana": "0.159"
+    "Mitjana": "0.159",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. BRUQUETAS"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.156"
+    "Mitjana": "0.156",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.14799999999999999"
+    "Mitjana": "0.14799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.14599999999999999"
+    "Mitjana": "0.14599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.108"
+    "Mitjana": "0.108",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "36",
     "Jugador": "P. BALLESTER",
-    "Mitjana": "0.106"
+    "Mitjana": "0.106",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. BALLESTER"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "37",
     "Jugador": "M. QUEROL",
-    "Mitjana": "8.4000000000000005E-2"
+    "Mitjana": "8.4000000000000005E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2015",
     "Modalitat": "3 BANDES",
     "Posició": "38",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "4.7E-2"
+    "Mitjana": "4.7E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "A. GÓMEZ",
-    "Mitjana": "0.49684210526315792"
+    "Mitjana": "0.49684210526315792",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. GÓMEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.45416666666666672"
+    "Mitjana": "0.45416666666666672",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J.M. CAMPOS",
-    "Mitjana": "0.42885375494071148"
+    "Mitjana": "0.42885375494071148",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CAMPOS"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.39010989010989011"
+    "Mitjana": "0.39010989010989011",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "L. CHUECOS",
-    "Mitjana": "0.388671875"
+    "Mitjana": "0.388671875",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. CHUECOS"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "J.L. ROSERÓ",
-    "Mitjana": "0.33267326732673269"
+    "Mitjana": "0.33267326732673269",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ROSERÓ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.33153153153153148"
+    "Mitjana": "0.33153153153153148",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.30412371134020622"
+    "Mitjana": "0.30412371134020622",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "A. MELGAREJO",
-    "Mitjana": "0.3"
+    "Mitjana": "0.3",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MELGAREJO"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "J. VILA",
-    "Mitjana": "0.2880658436213992"
+    "Mitjana": "0.2880658436213992",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VILA"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "A. FUENTES",
-    "Mitjana": "0.28545454545454552"
+    "Mitjana": "0.28545454545454552",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. FUENTES"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "0.28119180633147112"
+    "Mitjana": "0.28119180633147112",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.26719056974459732"
+    "Mitjana": "0.26719056974459732",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.26689774696707108"
+    "Mitjana": "0.26689774696707108",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.25486725663716808"
+    "Mitjana": "0.25486725663716808",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.24319419237749551"
+    "Mitjana": "0.24319419237749551",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.24231464737793851"
+    "Mitjana": "0.24231464737793851",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.23622047244094491"
+    "Mitjana": "0.23622047244094491",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "J. VEZA",
-    "Mitjana": "0.2281021897810219"
+    "Mitjana": "0.2281021897810219",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VEZA"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "E. GARCÍA",
-    "Mitjana": "0.2196078431372549"
+    "Mitjana": "0.2196078431372549",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. GARCÍA"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.21777003484320559"
+    "Mitjana": "0.21777003484320559",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.20304568527918779"
+    "Mitjana": "0.20304568527918779",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.20202020202020199"
+    "Mitjana": "0.20202020202020199",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "P. FERRÀS",
-    "Mitjana": "0.18166939443535191"
+    "Mitjana": "0.18166939443535191",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. FERRÀS"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.17123287671232881"
+    "Mitjana": "0.17123287671232881",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "J. GÓMEZ",
-    "Mitjana": "0.16987179487179491"
+    "Mitjana": "0.16987179487179491",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GÓMEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "M. GONZALVO",
-    "Mitjana": "0.16856060606060599"
+    "Mitjana": "0.16856060606060599",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GONZALVO"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "S. MARÍN",
-    "Mitjana": "0.16588419405320809"
+    "Mitjana": "0.16588419405320809",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. MARÍN"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.16428571428571431"
+    "Mitjana": "0.16428571428571431",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.16267123287671231"
+    "Mitjana": "0.16267123287671231",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.16236722306525039"
+    "Mitjana": "0.16236722306525039",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "A. MEDINA",
-    "Mitjana": "0.15957446808510639"
+    "Mitjana": "0.15957446808510639",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MEDINA"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "A. MORA",
-    "Mitjana": "0.1558641975308642"
+    "Mitjana": "0.1558641975308642",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MORA"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.15580286168521459"
+    "Mitjana": "0.15580286168521459",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "J. IBÁÑEZ",
-    "Mitjana": "0.1548599670510708"
+    "Mitjana": "0.1548599670510708",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. IBÁÑEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "36",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.12168486739469581"
+    "Mitjana": "0.12168486739469581",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "37",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.11492537313432841"
+    "Mitjana": "0.11492537313432841",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "38",
     "Jugador": "A. GARCÍA",
-    "Mitjana": "0.11248073959938371"
+    "Mitjana": "0.11248073959938371",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. GARCÍA"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "39",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.1075441412520064"
+    "Mitjana": "0.1075441412520064",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "40",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "9.8214285714285712E-2"
+    "Mitjana": "9.8214285714285712E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2025",
     "Modalitat": "3 BANDES",
     "Posició": "41",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "9.1044776119402981E-2"
+    "Mitjana": "9.1044776119402981E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "GARCÍA",
-    "Mitjana": "1.64"
+    "Mitjana": "1.64",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "GARCÍA"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.26"
+    "Mitjana": "1.26",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.25"
+    "Mitjana": "1.25",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "VIDAL",
-    "Mitjana": "1.0900000000000001"
+    "Mitjana": "1.0900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.99"
+    "Mitjana": "0.99",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "VIVAS",
-    "Mitjana": "0.98"
+    "Mitjana": "0.98",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "0.97"
+    "Mitjana": "0.97",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.78"
+    "Mitjana": "0.78",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "PUIG",
-    "Mitjana": "0.67"
+    "Mitjana": "0.67",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PUIG"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.62"
+    "Mitjana": "0.62",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "MIR",
-    "Mitjana": "0.56999999999999995"
+    "Mitjana": "0.56999999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.56000000000000005"
+    "Mitjana": "0.56000000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.53"
+    "Mitjana": "0.53",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "J. GRAU",
-    "Mitjana": "0.46"
+    "Mitjana": "0.46",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "TARES",
-    "Mitjana": "0.44"
+    "Mitjana": "0.44",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "JIMENO",
-    "Mitjana": "0.67"
+    "Mitjana": "0.67",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "JIMENO"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "DONADEU",
-    "Mitjana": "0.61"
+    "Mitjana": "0.61",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "DONADEU"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "PÉREZ",
-    "Mitjana": "0.48"
+    "Mitjana": "0.48",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PÉREZ"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "MAGRIÑA",
-    "Mitjana": "0.4"
+    "Mitjana": "0.4",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MAGRIÑA"
   },
   {
     "Any": "2003",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.35"
+    "Mitjana": "0.35",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.23"
+    "Mitjana": "1.23",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "VIDAL",
-    "Mitjana": "1.2"
+    "Mitjana": "1.2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.07"
+    "Mitjana": "1.07",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "VIVAS",
-    "Mitjana": "1.01"
+    "Mitjana": "1.01",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.87"
+    "Mitjana": "0.87",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.85"
+    "Mitjana": "0.85",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "J. GRAU",
-    "Mitjana": "0.76"
+    "Mitjana": "0.76",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "TALAVERA",
-    "Mitjana": "0.71"
+    "Mitjana": "0.71",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TALAVERA"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.61"
+    "Mitjana": "0.61",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "RUIZ",
-    "Mitjana": "0.61"
+    "Mitjana": "0.61",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RUIZ"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "TARES",
-    "Mitjana": "0.59"
+    "Mitjana": "0.59",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.56000000000000005"
+    "Mitjana": "0.56000000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.52"
+    "Mitjana": "0.52",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "TABERNER",
-    "Mitjana": "0.41"
+    "Mitjana": "0.41",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TABERNER"
   },
   {
     "Any": "2004",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.32"
+    "Mitjana": "0.32",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.43"
+    "Mitjana": "1.43",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.3"
+    "Mitjana": "1.3",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "1.2"
+    "Mitjana": "1.2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "VIVAS",
-    "Mitjana": "1.03"
+    "Mitjana": "1.03",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "VIDAL",
-    "Mitjana": "0.99"
+    "Mitjana": "0.99",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "X. FINA",
-    "Mitjana": "0.96"
+    "Mitjana": "0.96",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.95"
+    "Mitjana": "0.95",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.83"
+    "Mitjana": "0.83",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.76"
+    "Mitjana": "0.76",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "J. GRAU",
-    "Mitjana": "0.75"
+    "Mitjana": "0.75",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.73"
+    "Mitjana": "0.73",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "SERRA",
-    "Mitjana": "0.56000000000000005"
+    "Mitjana": "0.56000000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SERRA"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "MIR",
-    "Mitjana": "0.65500000000000003"
+    "Mitjana": "0.65500000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.65100000000000002"
+    "Mitjana": "0.65100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.59"
+    "Mitjana": "0.59",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "QUEVEDO",
-    "Mitjana": "0.52"
+    "Mitjana": "0.52",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "QUEVEDO"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "R. FINA",
-    "Mitjana": "0.51"
+    "Mitjana": "0.51",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. FINA"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "TARES",
-    "Mitjana": "0.5"
+    "Mitjana": "0.5",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.38"
+    "Mitjana": "0.38",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2005",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.28999999999999998"
+    "Mitjana": "0.28999999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "1.3"
+    "Mitjana": "1.3",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.1100000000000001"
+    "Mitjana": "1.1100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "VIDAL",
-    "Mitjana": "1.06"
+    "Mitjana": "1.06",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "J. SELGA",
-    "Mitjana": "1"
+    "Mitjana": "1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "VIVAS",
-    "Mitjana": "1"
+    "Mitjana": "1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.98"
+    "Mitjana": "0.98",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "X. FINA",
-    "Mitjana": "0.88600000000000001"
+    "Mitjana": "0.88600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.88200000000000001"
+    "Mitjana": "0.88200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.81"
+    "Mitjana": "0.81",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.78"
+    "Mitjana": "0.78",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.68"
+    "Mitjana": "0.68",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.73"
+    "Mitjana": "0.73",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "REAL",
-    "Mitjana": "0.65"
+    "Mitjana": "0.65",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "REAL"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "RODRÍGUEZ",
-    "Mitjana": "0.61"
+    "Mitjana": "0.61",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RODRÍGUEZ"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "TARES",
-    "Mitjana": "0.54"
+    "Mitjana": "0.54",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.51"
+    "Mitjana": "0.51",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2006",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "QUEVEDO",
-    "Mitjana": "0.48"
+    "Mitjana": "0.48",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "QUEVEDO"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "ALBARRACIN",
-    "Mitjana": "1.2"
+    "Mitjana": "1.2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALBARRACIN"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.1399999999999999"
+    "Mitjana": "1.1399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.1299999999999999"
+    "Mitjana": "1.1299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "1.1000000000000001"
+    "Mitjana": "1.1000000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.02"
+    "Mitjana": "1.02",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "VIDAL",
-    "Mitjana": "1"
+    "Mitjana": "1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "PALAU",
-    "Mitjana": "0.94"
+    "Mitjana": "0.94",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PALAU"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.86"
+    "Mitjana": "0.86",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.86"
+    "Mitjana": "0.86",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "X. FINA",
-    "Mitjana": "0.82"
+    "Mitjana": "0.82",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.79"
+    "Mitjana": "0.79",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "SELGAS",
-    "Mitjana": "0.78"
+    "Mitjana": "0.78",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.7"
+    "Mitjana": "0.7",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.6"
+    "Mitjana": "0.6",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "RODRÍGUEZ",
-    "Mitjana": "0.83"
+    "Mitjana": "0.83",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RODRÍGUEZ"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "BARRIENTOS",
-    "Mitjana": "0.81"
+    "Mitjana": "0.81",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIENTOS"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "TARES",
-    "Mitjana": "0.75"
+    "Mitjana": "0.75",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.63"
+    "Mitjana": "0.63",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "NOGUER",
-    "Mitjana": "0.61"
+    "Mitjana": "0.61",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "NOGUER"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "QUEVEDO",
-    "Mitjana": "0.54"
+    "Mitjana": "0.54",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "QUEVEDO"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.45"
+    "Mitjana": "0.45",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "MIR",
-    "Mitjana": "0.42"
+    "Mitjana": "0.42",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "MONTERO",
-    "Mitjana": "0.4"
+    "Mitjana": "0.4",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MONTERO"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.3"
+    "Mitjana": "0.3",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2007",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.23"
+    "Mitjana": "0.23",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.35"
+    "Mitjana": "1.35",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "ALBARRACIN",
-    "Mitjana": "1.33"
+    "Mitjana": "1.33",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALBARRACIN"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "GARCÍA",
-    "Mitjana": "1.32"
+    "Mitjana": "1.32",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "GARCÍA"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "VIDAL",
-    "Mitjana": "1.1299999999999999"
+    "Mitjana": "1.1299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "1.1100000000000001"
+    "Mitjana": "1.1100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "ROVIROSA",
-    "Mitjana": "1.08"
+    "Mitjana": "1.08",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ROVIROSA"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "0.95"
+    "Mitjana": "0.95",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "PALAU",
-    "Mitjana": "0.9"
+    "Mitjana": "0.9",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PALAU"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.89"
+    "Mitjana": "0.89",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.87"
+    "Mitjana": "0.87",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.83"
+    "Mitjana": "0.83",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.82"
+    "Mitjana": "0.82",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "BARRIENTOS",
-    "Mitjana": "0.81"
+    "Mitjana": "0.81",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIENTOS"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "J. GRAU",
-    "Mitjana": "0.76800000000000002"
+    "Mitjana": "0.76800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "HERNÁNDEZ",
-    "Mitjana": "0.76700000000000002"
+    "Mitjana": "0.76700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "HERNÁNDEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "RODRÍGUEZ",
-    "Mitjana": "0.7"
+    "Mitjana": "0.7",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RODRÍGUEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "SELGAS",
-    "Mitjana": "0.64"
+    "Mitjana": "0.64",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "ERRA",
-    "Mitjana": "0.63"
+    "Mitjana": "0.63",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ERRA"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "SOLANS",
-    "Mitjana": "0.62"
+    "Mitjana": "0.62",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SOLANS"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.61"
+    "Mitjana": "0.61",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "TARES",
-    "Mitjana": "0.56000000000000005"
+    "Mitjana": "0.56000000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "SERRA",
-    "Mitjana": "0.76"
+    "Mitjana": "0.76",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SERRA"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.73"
+    "Mitjana": "0.73",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.65"
+    "Mitjana": "0.65",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "NOGUER",
-    "Mitjana": "0.51"
+    "Mitjana": "0.51",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "NOGUER"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "MONTERO",
-    "Mitjana": "0.5"
+    "Mitjana": "0.5",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MONTERO"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.49099999999999999"
+    "Mitjana": "0.49099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "SUÑE",
-    "Mitjana": "0.49"
+    "Mitjana": "0.49",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SUÑE"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.39"
+    "Mitjana": "0.39",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2008",
     "Modalitat": "BANDA",
     "Posició": "30",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.25"
+    "Mitjana": "0.25",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "ALBARRACIN",
-    "Mitjana": "1.5149999999999999"
+    "Mitjana": "1.5149999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALBARRACIN"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "DURAN",
-    "Mitjana": "1.472"
+    "Mitjana": "1.472",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "DURAN"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.347"
+    "Mitjana": "1.347",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.1140000000000001"
+    "Mitjana": "1.1140000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "J. SELGA",
-    "Mitjana": "0.98199999999999998"
+    "Mitjana": "0.98199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "VIDAL",
-    "Mitjana": "0.93200000000000005"
+    "Mitjana": "0.93200000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "HERNANDEZ",
-    "Mitjana": "0.90800000000000003"
+    "Mitjana": "0.90800000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "HERNANDEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.88800000000000001"
+    "Mitjana": "0.88800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "X. FINA",
-    "Mitjana": "0.85699999999999998"
+    "Mitjana": "0.85699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "BARRIENTOS",
-    "Mitjana": "0.81799999999999995"
+    "Mitjana": "0.81799999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIENTOS"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "SELGAS",
-    "Mitjana": "0.67600000000000005"
+    "Mitjana": "0.67600000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "GRIÑO",
-    "Mitjana": "0.65700000000000003"
+    "Mitjana": "0.65700000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "GRIÑO"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.64500000000000002"
+    "Mitjana": "0.64500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "SERRA",
-    "Mitjana": "0.61799999999999999"
+    "Mitjana": "0.61799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SERRA"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "TARES",
-    "Mitjana": "0.57999999999999996"
+    "Mitjana": "0.57999999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.56599999999999995"
+    "Mitjana": "0.56599999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.53200000000000003"
+    "Mitjana": "0.53200000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "MARTÍNEZ",
-    "Mitjana": "0.49199999999999999"
+    "Mitjana": "0.49199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍNEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "PRAT",
-    "Mitjana": "0.48799999999999999"
+    "Mitjana": "0.48799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PRAT"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "ALMIRALL",
-    "Mitjana": "0.48399999999999999"
+    "Mitjana": "0.48399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALMIRALL"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "GÓMEZ",
-    "Mitjana": "0.48"
+    "Mitjana": "0.48",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "GÓMEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "MIR",
-    "Mitjana": "0.47299999999999998"
+    "Mitjana": "0.47299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.46800000000000003"
+    "Mitjana": "0.46800000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "NOGUER",
-    "Mitjana": "0.46100000000000002"
+    "Mitjana": "0.46100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "NOGUER"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.46"
+    "Mitjana": "0.46",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.39300000000000002"
+    "Mitjana": "0.39300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "PÉREZ",
-    "Mitjana": "0.33800000000000002"
+    "Mitjana": "0.33800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PÉREZ"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.316"
+    "Mitjana": "0.316",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2009",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.224"
+    "Mitjana": "0.224",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.2390000000000001"
+    "Mitjana": "1.2390000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.0660000000000001"
+    "Mitjana": "1.0660000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "1.052"
+    "Mitjana": "1.052",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.97499999999999998"
+    "Mitjana": "0.97499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.94899999999999995"
+    "Mitjana": "0.94899999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.93899999999999995"
+    "Mitjana": "0.93899999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "C. VIDAL",
-    "Mitjana": "0.92800000000000005"
+    "Mitjana": "0.92800000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "C. VIDAL"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "M. PALAU",
-    "Mitjana": "0.91200000000000003"
+    "Mitjana": "0.91200000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PALAU"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.81499999999999995"
+    "Mitjana": "0.81499999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "J. ROVIROSA",
-    "Mitjana": "0.80200000000000005"
+    "Mitjana": "0.80200000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ROVIROSA"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.78800000000000003"
+    "Mitjana": "0.78800000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.73699999999999999"
+    "Mitjana": "0.73699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "R. GRAU",
-    "Mitjana": "0.73599999999999999"
+    "Mitjana": "0.73599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.73499999999999999"
+    "Mitjana": "0.73499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.73499999999999999"
+    "Mitjana": "0.73499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.72799999999999998"
+    "Mitjana": "0.72799999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.70099999999999996"
+    "Mitjana": "0.70099999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.70099999999999996"
+    "Mitjana": "0.70099999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.67400000000000004"
+    "Mitjana": "0.67400000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.65600000000000003"
+    "Mitjana": "0.65600000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "J. MIR",
-    "Mitjana": "0.64"
+    "Mitjana": "0.64",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MIR"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "P. SERRA",
-    "Mitjana": "0.629"
+    "Mitjana": "0.629",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.58799999999999997"
+    "Mitjana": "0.58799999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "A. PORTA",
-    "Mitjana": "0.58699999999999997"
+    "Mitjana": "0.58699999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. PORTA"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.56399999999999995"
+    "Mitjana": "0.56399999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.55100000000000005"
+    "Mitjana": "0.55100000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "M. PRAT",
-    "Mitjana": "0.54800000000000004"
+    "Mitjana": "0.54800000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PRAT"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "F. GÓMEZ",
-    "Mitjana": "0.48299999999999998"
+    "Mitjana": "0.48299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. GÓMEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "M. ALMIRALL",
-    "Mitjana": "0.47199999999999998"
+    "Mitjana": "0.47199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. ALMIRALL"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "30",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.34899999999999998"
+    "Mitjana": "0.34899999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2011",
     "Modalitat": "BANDA",
     "Posició": "31",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.308"
+    "Mitjana": "0.308",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.141"
+    "Mitjana": "1.141",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.075"
+    "Mitjana": "1.075",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.0489999999999999"
+    "Mitjana": "1.0489999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.0329999999999999"
+    "Mitjana": "1.0329999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "A. PORTA",
-    "Mitjana": "1.032"
+    "Mitjana": "1.032",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. PORTA"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.90300000000000002"
+    "Mitjana": "0.90300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.86599999999999999"
+    "Mitjana": "0.86599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.81899999999999995"
+    "Mitjana": "0.81899999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "R. GRAU",
-    "Mitjana": "0.80900000000000005"
+    "Mitjana": "0.80900000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.77500000000000002"
+    "Mitjana": "0.77500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "P. SERRA",
-    "Mitjana": "0.75600000000000001"
+    "Mitjana": "0.75600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "R. COLOM",
-    "Mitjana": "0.754"
+    "Mitjana": "0.754",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.74099999999999999"
+    "Mitjana": "0.74099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.68799999999999994"
+    "Mitjana": "0.68799999999999994",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "X. FINA",
-    "Mitjana": "0.65200000000000002"
+    "Mitjana": "0.65200000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "E. GIRÓ",
-    "Mitjana": "0.64700000000000002"
+    "Mitjana": "0.64700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. GIRÓ"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.61"
+    "Mitjana": "0.61",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "J. GRIÑÓ",
-    "Mitjana": "0.60099999999999998"
+    "Mitjana": "0.60099999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRIÑÓ"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.57599999999999996"
+    "Mitjana": "0.57599999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "F. GÓMEZ",
-    "Mitjana": "0.56100000000000005"
+    "Mitjana": "0.56100000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. GÓMEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.53600000000000003"
+    "Mitjana": "0.53600000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.53"
+    "Mitjana": "0.53",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "M. PRAT",
-    "Mitjana": "0.50600000000000001"
+    "Mitjana": "0.50600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PRAT"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.5"
+    "Mitjana": "0.5",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "J. MIR",
-    "Mitjana": "0.46100000000000002"
+    "Mitjana": "0.46100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MIR"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.45400000000000001"
+    "Mitjana": "0.45400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.38"
+    "Mitjana": "0.38",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.38"
+    "Mitjana": "0.38",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2012",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.318"
+    "Mitjana": "0.318",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "1.6040000000000001"
+    "Mitjana": "1.6040000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.2869999999999999"
+    "Mitjana": "1.2869999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.1599999999999999"
+    "Mitjana": "1.1599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.0840000000000001"
+    "Mitjana": "1.0840000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "V. HAMMER",
-    "Mitjana": "1.0509999999999999"
+    "Mitjana": "1.0509999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. HAMMER"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "J. COMAS",
-    "Mitjana": "1.034"
+    "Mitjana": "1.034",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.022"
+    "Mitjana": "1.022",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "R. GRAU",
-    "Mitjana": "0.98"
+    "Mitjana": "0.98",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.82399999999999995"
+    "Mitjana": "0.82399999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.82199999999999995"
+    "Mitjana": "0.82199999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.77700000000000002"
+    "Mitjana": "0.77700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.745"
+    "Mitjana": "0.745",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.72399999999999998"
+    "Mitjana": "0.72399999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.72399999999999998"
+    "Mitjana": "0.72399999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.71399999999999997"
+    "Mitjana": "0.71399999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "X. FINA",
-    "Mitjana": "0.69599999999999995"
+    "Mitjana": "0.69599999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.66400000000000003"
+    "Mitjana": "0.66400000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "P. SERRA",
-    "Mitjana": "0.66100000000000003"
+    "Mitjana": "0.66100000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.59499999999999997"
+    "Mitjana": "0.59499999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.58699999999999997"
+    "Mitjana": "0.58699999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.53500000000000003"
+    "Mitjana": "0.53500000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.52800000000000002"
+    "Mitjana": "0.52800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.498"
+    "Mitjana": "0.498",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.46500000000000002"
+    "Mitjana": "0.46500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "M. BRUQUETAS",
-    "Mitjana": "0.46200000000000002"
+    "Mitjana": "0.46200000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. BRUQUETAS"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.46"
+    "Mitjana": "0.46",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.46"
+    "Mitjana": "0.46",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.44900000000000001"
+    "Mitjana": "0.44900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.42699999999999999"
+    "Mitjana": "0.42699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "30",
     "Jugador": "P. BALLESTER",
-    "Mitjana": "0.377"
+    "Mitjana": "0.377",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. BALLESTER"
   },
   {
     "Any": "2013",
     "Modalitat": "BANDA",
     "Posició": "31",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.33600000000000002"
+    "Mitjana": "0.33600000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "1.42"
+    "Mitjana": "1.42",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.1399999999999999"
+    "Mitjana": "1.1399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "V. HAMMER",
-    "Mitjana": "1.1200000000000001"
+    "Mitjana": "1.1200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. HAMMER"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.103"
+    "Mitjana": "1.103",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.0860000000000001"
+    "Mitjana": "1.0860000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "E. LUENGO",
-    "Mitjana": "0.86599999999999999"
+    "Mitjana": "0.86599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LUENGO"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.82499999999999996"
+    "Mitjana": "0.82499999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.76"
+    "Mitjana": "0.76",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.754"
+    "Mitjana": "0.754",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.74399999999999999"
+    "Mitjana": "0.74399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.72299999999999998"
+    "Mitjana": "0.72299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.70399999999999996"
+    "Mitjana": "0.70399999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.70099999999999996"
+    "Mitjana": "0.70099999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.7"
+    "Mitjana": "0.7",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.69699999999999995"
+    "Mitjana": "0.69699999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "A. CAMPILLO",
-    "Mitjana": "0.65500000000000003"
+    "Mitjana": "0.65500000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CAMPILLO"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.61799999999999999"
+    "Mitjana": "0.61799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.61399999999999999"
+    "Mitjana": "0.61399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.61299999999999999"
+    "Mitjana": "0.61299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.61199999999999999"
+    "Mitjana": "0.61199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.58299999999999996"
+    "Mitjana": "0.58299999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.54200000000000004"
+    "Mitjana": "0.54200000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.505"
+    "Mitjana": "0.505",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.48399999999999999"
+    "Mitjana": "0.48399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.46800000000000003"
+    "Mitjana": "0.46800000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.45900000000000002"
+    "Mitjana": "0.45900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.44900000000000001"
+    "Mitjana": "0.44900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "S. MARÍN",
-    "Mitjana": "0.44700000000000001"
+    "Mitjana": "0.44700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. MARÍN"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "M. BRUQUETAS",
-    "Mitjana": "0.434"
+    "Mitjana": "0.434",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. BRUQUETAS"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "30",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.432"
+    "Mitjana": "0.432",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "31",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.36299999999999999"
+    "Mitjana": "0.36299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "32",
     "Jugador": "J. MONTERO",
-    "Mitjana": "0.33600000000000002"
+    "Mitjana": "0.33600000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MONTERO"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "33",
     "Jugador": "P. BALLESTER",
-    "Mitjana": "0.32200000000000001"
+    "Mitjana": "0.32200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. BALLESTER"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "34",
     "Jugador": "J. ARMENGOL",
-    "Mitjana": "0.30399999999999999"
+    "Mitjana": "0.30399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ARMENGOL"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "35",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.26600000000000001"
+    "Mitjana": "0.26600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "36",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.19400000000000001"
+    "Mitjana": "0.19400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2014",
     "Modalitat": "BANDA",
     "Posició": "37",
     "Jugador": "R. BURÉS",
-    "Mitjana": "0.19400000000000001"
+    "Mitjana": "0.19400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. BURÉS"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.95099999999999996"
+    "Mitjana": "0.95099999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "I. HERNÁNDEZ",
-    "Mitjana": "0.94599999999999995"
+    "Mitjana": "0.94599999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. HERNÁNDEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.88700000000000001"
+    "Mitjana": "0.88700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.88100000000000001"
+    "Mitjana": "0.88100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.872"
+    "Mitjana": "0.872",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.86599999999999999"
+    "Mitjana": "0.86599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "J. MUÑOZ",
-    "Mitjana": "0.85899999999999999"
+    "Mitjana": "0.85899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MUÑOZ"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "R. MORENO",
-    "Mitjana": "0.76600000000000001"
+    "Mitjana": "0.76600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "A. TRILLO",
-    "Mitjana": "0.70899999999999996"
+    "Mitjana": "0.70899999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. TRILLO"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.70199999999999996"
+    "Mitjana": "0.70199999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.67900000000000005"
+    "Mitjana": "0.67900000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.64400000000000002"
+    "Mitjana": "0.64400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "D. CORBALÁN",
-    "Mitjana": "0.57799999999999996"
+    "Mitjana": "0.57799999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "D. CORBALÁN"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.55000000000000004"
+    "Mitjana": "0.55000000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.53200000000000003"
+    "Mitjana": "0.53200000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.50600000000000001"
+    "Mitjana": "0.50600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.46300000000000002"
+    "Mitjana": "0.46300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.441"
+    "Mitjana": "0.441",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.44"
+    "Mitjana": "0.44",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.43099999999999999"
+    "Mitjana": "0.43099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "A. DEL RIO",
-    "Mitjana": "0.39"
+    "Mitjana": "0.39",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. DEL RIO"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.38500000000000001"
+    "Mitjana": "0.38500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.376"
+    "Mitjana": "0.376",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "E. ROYES",
-    "Mitjana": "0.36499999999999999"
+    "Mitjana": "0.36499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. ROYES"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.34699999999999998"
+    "Mitjana": "0.34699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "A. MORA",
-    "Mitjana": "0.309"
+    "Mitjana": "0.309",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MORA"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.307"
+    "Mitjana": "0.307",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.30099999999999999"
+    "Mitjana": "0.30099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "30",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.28000000000000003"
+    "Mitjana": "0.28000000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "31",
     "Jugador": "J. GRAU",
-    "Mitjana": "0.28000000000000003"
+    "Mitjana": "0.28000000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "32",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.27"
+    "Mitjana": "0.27",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2021",
     "Modalitat": "BANDA",
     "Posició": "33",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.25600000000000001"
+    "Mitjana": "0.25600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "1.155"
+    "Mitjana": "1.155",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.127"
+    "Mitjana": "1.127",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.95499999999999996"
+    "Mitjana": "0.95499999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.84399999999999997"
+    "Mitjana": "0.84399999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.84299999999999997"
+    "Mitjana": "0.84299999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "A. MELGAREJO",
-    "Mitjana": "0.83"
+    "Mitjana": "0.83",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MELGAREJO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.77"
+    "Mitjana": "0.77",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.74399999999999999"
+    "Mitjana": "0.74399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "R. MORENO",
-    "Mitjana": "0.71299999999999997"
+    "Mitjana": "0.71299999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.70599999999999996"
+    "Mitjana": "0.70599999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "A. TRILLO",
-    "Mitjana": "0.67"
+    "Mitjana": "0.67",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. TRILLO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.629"
+    "Mitjana": "0.629",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "0.61799999999999999"
+    "Mitjana": "0.61799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.61299999999999999"
+    "Mitjana": "0.61299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "D. CORBALÁN",
-    "Mitjana": "0.54600000000000004"
+    "Mitjana": "0.54600000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "D. CORBALÁN"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.54"
+    "Mitjana": "0.54",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.50900000000000001"
+    "Mitjana": "0.50900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.49"
+    "Mitjana": "0.49",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "J. IBÁÑEZ",
-    "Mitjana": "0.47499999999999998"
+    "Mitjana": "0.47499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. IBÁÑEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "F. LEDO",
-    "Mitjana": "0.46"
+    "Mitjana": "0.46",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. LEDO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.45900000000000002"
+    "Mitjana": "0.45900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.42899999999999999"
+    "Mitjana": "0.42899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.41699999999999998"
+    "Mitjana": "0.41699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.4"
+    "Mitjana": "0.4",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.38300000000000001"
+    "Mitjana": "0.38300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.378"
+    "Mitjana": "0.378",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.33400000000000002"
+    "Mitjana": "0.33400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "E. ROYES",
-    "Mitjana": "0.32600000000000001"
+    "Mitjana": "0.32600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. ROYES"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.29299999999999998"
+    "Mitjana": "0.29299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "30",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.27100000000000002"
+    "Mitjana": "0.27100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "31",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.26800000000000002"
+    "Mitjana": "0.26800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "32",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.26600000000000001"
+    "Mitjana": "0.26600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "33",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.36299999999999999"
+    "Mitjana": "0.36299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2022",
     "Modalitat": "BANDA",
     "Posició": "34",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.33600000000000002"
+    "Mitjana": "0.33600000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "1.2869999999999999"
+    "Mitjana": "1.2869999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.1259999999999999"
+    "Mitjana": "1.1259999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "I. HERNÁNDEZ",
-    "Mitjana": "1.0489999999999999"
+    "Mitjana": "1.0489999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. HERNÁNDEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "1.0049999999999999"
+    "Mitjana": "1.0049999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.98899999999999999"
+    "Mitjana": "0.98899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "A. MELGAREJO",
-    "Mitjana": "0.95499999999999996"
+    "Mitjana": "0.95499999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MELGAREJO"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.92900000000000005"
+    "Mitjana": "0.92900000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "P. RUIZ",
-    "Mitjana": "0.82399999999999995"
+    "Mitjana": "0.82399999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. RUIZ"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.80300000000000005"
+    "Mitjana": "0.80300000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "A. TRILLO",
-    "Mitjana": "0.76900000000000002"
+    "Mitjana": "0.76900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. TRILLO"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.68200000000000005"
+    "Mitjana": "0.68200000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "0.66"
+    "Mitjana": "0.66",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.6"
+    "Mitjana": "0.6",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "J. VEZA",
-    "Mitjana": "0.57899999999999996"
+    "Mitjana": "0.57899999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VEZA"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.57399999999999995"
+    "Mitjana": "0.57399999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.55800000000000005"
+    "Mitjana": "0.55800000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.53300000000000003"
+    "Mitjana": "0.53300000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "F. LEDO",
-    "Mitjana": "0.52400000000000002"
+    "Mitjana": "0.52400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. LEDO"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.504"
+    "Mitjana": "0.504",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.49399999999999999"
+    "Mitjana": "0.49399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.48799999999999999"
+    "Mitjana": "0.48799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.45200000000000001"
+    "Mitjana": "0.45200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.42199999999999999"
+    "Mitjana": "0.42199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.41899999999999998"
+    "Mitjana": "0.41899999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "A. MORA",
-    "Mitjana": "0.41299999999999998"
+    "Mitjana": "0.41299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MORA"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "A. MEDINA",
-    "Mitjana": "0.379"
+    "Mitjana": "0.379",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MEDINA"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.34"
+    "Mitjana": "0.34",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.33300000000000002"
+    "Mitjana": "0.33300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.317"
+    "Mitjana": "0.317",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "30",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.313"
+    "Mitjana": "0.313",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "31",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.28799999999999998"
+    "Mitjana": "0.28799999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "32",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.28199999999999997"
+    "Mitjana": "0.28199999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2023",
     "Modalitat": "BANDA",
     "Posició": "33",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.255"
+    "Mitjana": "0.255",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "1.318807339449541"
+    "Mitjana": "1.318807339449541",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "L. CHUECOS",
-    "Mitjana": "1.134502923976608"
+    "Mitjana": "1.134502923976608",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. CHUECOS"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.1298174442190669"
+    "Mitjana": "1.1298174442190669",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "A. BOIX",
-    "Mitjana": "1.0362595419847329"
+    "Mitjana": "1.0362595419847329",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "I. HERNÁNDEZ",
-    "Mitjana": "1.007547169811321"
+    "Mitjana": "1.007547169811321",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. HERNÁNDEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "A. GÓMEZ",
-    "Mitjana": "0.93320610687022898"
+    "Mitjana": "0.93320610687022898",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. GÓMEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.93103448275862066"
+    "Mitjana": "0.93103448275862066",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.87413793103448278"
+    "Mitjana": "0.87413793103448278",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "R. MORENO",
-    "Mitjana": "0.84836852207293667"
+    "Mitjana": "0.84836852207293667",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.81237911025145071"
+    "Mitjana": "0.81237911025145071",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "0.80073800738007384"
+    "Mitjana": "0.80073800738007384",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.77333333333333332"
+    "Mitjana": "0.77333333333333332",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "J.L. ROSERÓ",
-    "Mitjana": "0.74128440366972481"
+    "Mitjana": "0.74128440366972481",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ROSERÓ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.7182795698924731"
+    "Mitjana": "0.7182795698924731",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "J. VEZA",
-    "Mitjana": "0.69807692307692304"
+    "Mitjana": "0.69807692307692304",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VEZA"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.66666666666666663"
+    "Mitjana": "0.66666666666666663",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.63617463617463621"
+    "Mitjana": "0.63617463617463621",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.58935361216730042"
+    "Mitjana": "0.58935361216730042",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.58502024291497978"
+    "Mitjana": "0.58502024291497978",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.56302521008403361"
+    "Mitjana": "0.56302521008403361",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "F. LEDO",
-    "Mitjana": "0.53614457831325302"
+    "Mitjana": "0.53614457831325302",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. LEDO"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.51851851851851849"
+    "Mitjana": "0.51851851851851849",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "M. GONZALVO",
-    "Mitjana": "0.48440748440748438"
+    "Mitjana": "0.48440748440748438",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GONZALVO"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "J. IBÁÑEZ",
-    "Mitjana": "0.46774193548387089"
+    "Mitjana": "0.46774193548387089",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. IBÁÑEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.45306122448979591"
+    "Mitjana": "0.45306122448979591",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.44800000000000001"
+    "Mitjana": "0.44800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.39959432048681542"
+    "Mitjana": "0.39959432048681542",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.36105476673427989"
+    "Mitjana": "0.36105476673427989",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.36"
+    "Mitjana": "0.36",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "30",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.32464929859719438"
+    "Mitjana": "0.32464929859719438",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "31",
     "Jugador": "E. ROYES",
-    "Mitjana": "0.32200000000000001"
+    "Mitjana": "0.32200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. ROYES"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "32",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.27902240325865579"
+    "Mitjana": "0.27902240325865579",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "33",
     "Jugador": "A. MEDINA",
-    "Mitjana": "0.442"
+    "Mitjana": "0.442",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MEDINA"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "34",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.40442655935613681"
+    "Mitjana": "0.40442655935613681",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "35",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.25600000000000001"
+    "Mitjana": "0.25600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2024",
     "Modalitat": "BANDA",
     "Posició": "36",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.24"
+    "Mitjana": "0.24",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "1",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.91300000000000003"
+    "Mitjana": "0.91300000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "2",
     "Jugador": "J.M. CAMPOS",
-    "Mitjana": "0.879"
+    "Mitjana": "0.879",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CAMPOS"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "3",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "1.071"
+    "Mitjana": "1.071",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "4",
     "Jugador": "L. CHUECOS",
-    "Mitjana": "1.345"
+    "Mitjana": "1.345",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. CHUECOS"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "5",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.873"
+    "Mitjana": "0.873",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "6",
     "Jugador": "J. DOMINGO",
-    "Mitjana": "0.83499999999999996"
+    "Mitjana": "0.83499999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. DOMINGO"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "7",
     "Jugador": "A. GÓMEZ",
-    "Mitjana": "1.008"
+    "Mitjana": "1.008",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. GÓMEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "8",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.002"
+    "Mitjana": "1.002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "9",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "1.244"
+    "Mitjana": "1.244",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "10",
     "Jugador": "J. VILA",
-    "Mitjana": "1.0069999999999999"
+    "Mitjana": "1.0069999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VILA"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "11",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "0.73099999999999998"
+    "Mitjana": "0.73099999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "12",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.65700000000000003"
+    "Mitjana": "0.65700000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "13",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.65500000000000003"
+    "Mitjana": "0.65500000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "14",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.57099999999999995"
+    "Mitjana": "0.57099999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "15",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.55100000000000005"
+    "Mitjana": "0.55100000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "16",
     "Jugador": "E. LUENGO",
-    "Mitjana": "0.80500000000000005"
+    "Mitjana": "0.80500000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LUENGO"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "17",
     "Jugador": "R. MORENO",
-    "Mitjana": "0.80600000000000005"
+    "Mitjana": "0.80600000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "18",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.47099999999999997"
+    "Mitjana": "0.47099999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "19",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.85299999999999998"
+    "Mitjana": "0.85299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "20",
     "Jugador": "J.L. ROSERÓ",
-    "Mitjana": "0.81100000000000005"
+    "Mitjana": "0.81100000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ROSERÓ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "21",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.496"
+    "Mitjana": "0.496",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "22",
     "Jugador": "E. GARCÍA",
-    "Mitjana": "0.55200000000000005"
+    "Mitjana": "0.55200000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. GARCÍA"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "23",
     "Jugador": "J. GÓMEZ",
-    "Mitjana": "0.52900000000000003"
+    "Mitjana": "0.52900000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GÓMEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "24",
     "Jugador": "M. GONZALVO",
-    "Mitjana": "0.438"
+    "Mitjana": "0.438",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GONZALVO"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "25",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.40500000000000003"
+    "Mitjana": "0.40500000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "26",
     "Jugador": "S. MARÍN",
-    "Mitjana": "0.29099999999999998"
+    "Mitjana": "0.29099999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. MARÍN"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "27",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.38300000000000001"
+    "Mitjana": "0.38300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "28",
     "Jugador": "J. SÁNCHEZ",
-    "Mitjana": "0.67700000000000005"
+    "Mitjana": "0.67700000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SÁNCHEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "29",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.48699999999999999"
+    "Mitjana": "0.48699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "30",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.39300000000000002"
+    "Mitjana": "0.39300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "31",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.26"
+    "Mitjana": "0.26",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "32",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.36699999999999999"
+    "Mitjana": "0.36699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "33",
     "Jugador": "A. MEDINA",
-    "Mitjana": "0.43"
+    "Mitjana": "0.43",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MEDINA"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "34",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.35499999999999998"
+    "Mitjana": "0.35499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "35",
     "Jugador": "G. RUIZ",
-    "Mitjana": "0.378"
+    "Mitjana": "0.378",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. RUIZ"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "36",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.443"
+    "Mitjana": "0.443",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "37",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.30499999999999999"
+    "Mitjana": "0.30499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2025",
     "Modalitat": "BANDA",
     "Posició": "38",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.23300000000000001"
+    "Mitjana": "0.23300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "1.9650000000000001"
+    "Mitjana": "1.9650000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.7729999999999999"
+    "Mitjana": "1.7729999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.6719999999999999"
+    "Mitjana": "1.6719999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "VIDAL",
-    "Mitjana": "1.512"
+    "Mitjana": "1.512",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "1.3839999999999999"
+    "Mitjana": "1.3839999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.339"
+    "Mitjana": "1.339",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "J. GRAU",
-    "Mitjana": "1.153"
+    "Mitjana": "1.153",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "PUIG",
-    "Mitjana": "1"
+    "Mitjana": "1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PUIG"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.91200000000000003"
+    "Mitjana": "0.91200000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.875"
+    "Mitjana": "0.875",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "TARES",
-    "Mitjana": "0.84899999999999998"
+    "Mitjana": "0.84899999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.81599999999999995"
+    "Mitjana": "0.81599999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "MIR",
-    "Mitjana": "0.80600000000000005"
+    "Mitjana": "0.80600000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "MARTÍNEZ",
-    "Mitjana": "0.80500000000000005"
+    "Mitjana": "0.80500000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍNEZ"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "DONADEU",
-    "Mitjana": "0.754"
+    "Mitjana": "0.754",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "DONADEU"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "CASBAS",
-    "Mitjana": "0.72199999999999998"
+    "Mitjana": "0.72199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "CASBAS"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "MAGRIÑA",
-    "Mitjana": "0.59499999999999997"
+    "Mitjana": "0.59499999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MAGRIÑA"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "PÉREZ",
-    "Mitjana": "0.54300000000000004"
+    "Mitjana": "0.54300000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PÉREZ"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "BARRIERE",
-    "Mitjana": "0.48099999999999998"
+    "Mitjana": "0.48099999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIERE"
   },
   {
     "Any": "2003",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.47499999999999998"
+    "Mitjana": "0.47499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "RAMÍREZ",
-    "Mitjana": "2.2599999999999998"
+    "Mitjana": "2.2599999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RAMÍREZ"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "ALCARAZ",
-    "Mitjana": "2.2400000000000002"
+    "Mitjana": "2.2400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALCARAZ"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.98"
+    "Mitjana": "1.98",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.84"
+    "Mitjana": "1.84",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.83"
+    "Mitjana": "1.83",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "VIDAL",
-    "Mitjana": "1.52"
+    "Mitjana": "1.52",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "1.26"
+    "Mitjana": "1.26",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "J. GRAU",
-    "Mitjana": "1.1499999999999999"
+    "Mitjana": "1.1499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "PUIG",
-    "Mitjana": "1.04"
+    "Mitjana": "1.04",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PUIG"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.99"
+    "Mitjana": "0.99",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.85"
+    "Mitjana": "0.85",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.75"
+    "Mitjana": "0.75",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "TARES",
-    "Mitjana": "0.71"
+    "Mitjana": "0.71",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "NOGUER",
-    "Mitjana": "0.68"
+    "Mitjana": "0.68",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "NOGUER"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "PÉREZ",
-    "Mitjana": "0.67"
+    "Mitjana": "0.67",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PÉREZ"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "CASBAS",
-    "Mitjana": "0.67"
+    "Mitjana": "0.67",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "CASBAS"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "X. FINA",
-    "Mitjana": "0.63"
+    "Mitjana": "0.63",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "BARRIERE",
-    "Mitjana": "0.55000000000000004"
+    "Mitjana": "0.55000000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIERE"
   },
   {
     "Any": "2004",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.51"
+    "Mitjana": "0.51",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "ALCARAZ",
-    "Mitjana": "2.5299999999999998"
+    "Mitjana": "2.5299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALCARAZ"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "1.91"
+    "Mitjana": "1.91",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.68"
+    "Mitjana": "1.68",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "VIDAL",
-    "Mitjana": "1.61"
+    "Mitjana": "1.61",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.6"
+    "Mitjana": "1.6",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.58"
+    "Mitjana": "1.58",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "VIVAS",
-    "Mitjana": "1.49"
+    "Mitjana": "1.49",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.47"
+    "Mitjana": "1.47",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "X. FINA",
-    "Mitjana": "1.34"
+    "Mitjana": "1.34",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "J. GRAU",
-    "Mitjana": "1.18"
+    "Mitjana": "1.18",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "1.17"
+    "Mitjana": "1.17",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "R. COLOM",
-    "Mitjana": "1.1599999999999999"
+    "Mitjana": "1.1599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "SELGAS",
-    "Mitjana": "1.1299999999999999"
+    "Mitjana": "1.1299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "SERRA",
-    "Mitjana": "1.1299999999999999"
+    "Mitjana": "1.1299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SERRA"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "1.02"
+    "Mitjana": "1.02",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "TARES",
-    "Mitjana": "1.22"
+    "Mitjana": "1.22",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "MIR",
-    "Mitjana": "1.02"
+    "Mitjana": "1.02",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "1.02"
+    "Mitjana": "1.02",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "FARRE",
-    "Mitjana": "0.95"
+    "Mitjana": "0.95",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "FARRE"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.84"
+    "Mitjana": "0.84",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "PEÑA",
-    "Mitjana": "0.83"
+    "Mitjana": "0.83",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PEÑA"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "SUÑE",
-    "Mitjana": "0.81"
+    "Mitjana": "0.81",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SUÑE"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "QUEVEDO",
-    "Mitjana": "0.75"
+    "Mitjana": "0.75",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "QUEVEDO"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.47"
+    "Mitjana": "0.47",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2005",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.45"
+    "Mitjana": "0.45",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "2.7"
+    "Mitjana": "2.7",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "ALCARAZ",
-    "Mitjana": "2.4"
+    "Mitjana": "2.4",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALCARAZ"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.94"
+    "Mitjana": "1.94",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.8"
+    "Mitjana": "1.8",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.78"
+    "Mitjana": "1.78",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "VIDAL",
-    "Mitjana": "1.51"
+    "Mitjana": "1.51",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.47"
+    "Mitjana": "1.47",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "R. COLOM",
-    "Mitjana": "1.35"
+    "Mitjana": "1.35",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "X. FINA",
-    "Mitjana": "1.29"
+    "Mitjana": "1.29",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "1.17"
+    "Mitjana": "1.17",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "1.05"
+    "Mitjana": "1.05",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "TARES",
-    "Mitjana": "0.87"
+    "Mitjana": "0.87",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "MIR",
-    "Mitjana": "1.06"
+    "Mitjana": "1.06",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MIR"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.97"
+    "Mitjana": "0.97",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.86"
+    "Mitjana": "0.86",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "FARRE",
-    "Mitjana": "0.85"
+    "Mitjana": "0.85",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "FARRE"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "PEÑA",
-    "Mitjana": "0.84"
+    "Mitjana": "0.84",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PEÑA"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "QUEVEDO",
-    "Mitjana": "0.79"
+    "Mitjana": "0.79",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "QUEVEDO"
   },
   {
     "Any": "2006",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.5"
+    "Mitjana": "0.5",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "ALCARAZ",
-    "Mitjana": "2.41"
+    "Mitjana": "2.41",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALCARAZ"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "1.97"
+    "Mitjana": "1.97",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "J. COMAS",
-    "Mitjana": "1.96"
+    "Mitjana": "1.96",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.94"
+    "Mitjana": "1.94",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.91"
+    "Mitjana": "1.91",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "VIDAL",
-    "Mitjana": "1.75"
+    "Mitjana": "1.75",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.7"
+    "Mitjana": "1.7",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.46"
+    "Mitjana": "1.46",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "R. COLOM",
-    "Mitjana": "1.4"
+    "Mitjana": "1.4",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "PALAU",
-    "Mitjana": "1.25"
+    "Mitjana": "1.25",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PALAU"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "SELGAS",
-    "Mitjana": "1.17"
+    "Mitjana": "1.17",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "X. FINA",
-    "Mitjana": "1.1100000000000001"
+    "Mitjana": "1.1100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "1.0900000000000001"
+    "Mitjana": "1.0900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.89"
+    "Mitjana": "0.89",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "BARRIENTOS",
-    "Mitjana": "1.31"
+    "Mitjana": "1.31",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIENTOS"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "1.1100000000000001"
+    "Mitjana": "1.1100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "RODRÍGUEZ",
-    "Mitjana": "1.1000000000000001"
+    "Mitjana": "1.1000000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RODRÍGUEZ"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "1.05"
+    "Mitjana": "1.05",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "REAL",
-    "Mitjana": "1"
+    "Mitjana": "1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "REAL"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "GRIÑO",
-    "Mitjana": "0.99"
+    "Mitjana": "0.99",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "GRIÑO"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.95"
+    "Mitjana": "0.95",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "TARES",
-    "Mitjana": "0.9"
+    "Mitjana": "0.9",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "NOGUER",
-    "Mitjana": "0.88"
+    "Mitjana": "0.88",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "NOGUER"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.81"
+    "Mitjana": "0.81",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.7"
+    "Mitjana": "0.7",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "QUEVEDO",
-    "Mitjana": "0.66"
+    "Mitjana": "0.66",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "QUEVEDO"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "SUÑE",
-    "Mitjana": "0.6"
+    "Mitjana": "0.6",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SUÑE"
   },
   {
     "Any": "2007",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.51"
+    "Mitjana": "0.51",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "2.4700000000000002"
+    "Mitjana": "2.4700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "ALCARAZ",
-    "Mitjana": "2.37"
+    "Mitjana": "2.37",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALCARAZ"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "ALBARRACIN",
-    "Mitjana": "2.1800000000000002"
+    "Mitjana": "2.1800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ALBARRACIN"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "J. GELABERT",
-    "Mitjana": "2.06"
+    "Mitjana": "2.06",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "J. SELGA",
-    "Mitjana": "2.0099999999999998"
+    "Mitjana": "2.0099999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "J. COMAS",
-    "Mitjana": "1.65"
+    "Mitjana": "1.65",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "PALAU",
-    "Mitjana": "1.5"
+    "Mitjana": "1.5",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PALAU"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "P. COMAS",
-    "Mitjana": "1.44"
+    "Mitjana": "1.44",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. COMAS"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "1.4"
+    "Mitjana": "1.4",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.32"
+    "Mitjana": "1.32",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "VIVAS",
-    "Mitjana": "1.23"
+    "Mitjana": "1.23",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIVAS"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "J. GRAU",
-    "Mitjana": "1.1599999999999999"
+    "Mitjana": "1.1599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "HERNÁNDEZ",
-    "Mitjana": "1.1399999999999999"
+    "Mitjana": "1.1399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "HERNÁNDEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "1.0900000000000001"
+    "Mitjana": "1.0900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "SELGAS",
-    "Mitjana": "1.06"
+    "Mitjana": "1.06",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "BARRIENTOS",
-    "Mitjana": "1.03"
+    "Mitjana": "1.03",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIENTOS"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "1.34"
+    "Mitjana": "1.34",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "GRIÑO",
-    "Mitjana": "1.22"
+    "Mitjana": "1.22",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "GRIÑO"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "RODRÍGUEZ",
-    "Mitjana": "1.1000000000000001"
+    "Mitjana": "1.1000000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RODRÍGUEZ"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.87"
+    "Mitjana": "0.87",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "SERRA",
-    "Mitjana": "1.01"
+    "Mitjana": "1.01",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SERRA"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "NOGUER",
-    "Mitjana": "0.9"
+    "Mitjana": "0.9",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "NOGUER"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.87"
+    "Mitjana": "0.87",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.78"
+    "Mitjana": "0.78",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "SUÑE",
-    "Mitjana": "0.76"
+    "Mitjana": "0.76",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SUÑE"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "QUEVEDO",
-    "Mitjana": "0.65"
+    "Mitjana": "0.65",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "QUEVEDO"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "MONTERO",
-    "Mitjana": "0.64"
+    "Mitjana": "0.64",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MONTERO"
   },
   {
     "Any": "2008",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.48"
+    "Mitjana": "0.48",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "DURAN",
-    "Mitjana": "2.3290000000000002"
+    "Mitjana": "2.3290000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "DURAN"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "ROVIROSA",
-    "Mitjana": "1.85"
+    "Mitjana": "1.85",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ROVIROSA"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.83"
+    "Mitjana": "1.83",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.6779999999999999"
+    "Mitjana": "1.6779999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "VIDAL",
-    "Mitjana": "1.4490000000000001"
+    "Mitjana": "1.4490000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "VIDAL"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "1.4319999999999999"
+    "Mitjana": "1.4319999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "RODRÍGUEZ",
-    "Mitjana": "1.248"
+    "Mitjana": "1.248",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "RODRÍGUEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.177"
+    "Mitjana": "1.177",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "R. COLOM",
-    "Mitjana": "1.151"
+    "Mitjana": "1.151",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "BARRIENTOS",
-    "Mitjana": "1.143"
+    "Mitjana": "1.143",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "BARRIENTOS"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "PALAU",
-    "Mitjana": "1.129"
+    "Mitjana": "1.129",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "PALAU"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "1.1140000000000001"
+    "Mitjana": "1.1140000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "TARES",
-    "Mitjana": "1.0509999999999999"
+    "Mitjana": "1.0509999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "TARES"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "J. GRAU",
-    "Mitjana": "1.014"
+    "Mitjana": "1.014",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRAU"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "1.01"
+    "Mitjana": "1.01",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "GRIÑO",
-    "Mitjana": "1"
+    "Mitjana": "1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "GRIÑO"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "HERNANDEZ",
-    "Mitjana": "0.96299999999999997"
+    "Mitjana": "0.96299999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "HERNANDEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "SELGAS",
-    "Mitjana": "0.94899999999999995"
+    "Mitjana": "0.94899999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SELGAS"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.91900000000000004"
+    "Mitjana": "0.91900000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "SOLANES",
-    "Mitjana": "0.85399999999999998"
+    "Mitjana": "0.85399999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "SOLANES"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.80300000000000005"
+    "Mitjana": "0.80300000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "J. ARMENGOL",
-    "Mitjana": "0.73599999999999999"
+    "Mitjana": "0.73599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ARMENGOL"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.69299999999999995"
+    "Mitjana": "0.69299999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "NOGUER",
-    "Mitjana": "0.68700000000000006"
+    "Mitjana": "0.68700000000000006",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "NOGUER"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "MONTERO",
-    "Mitjana": "0.68300000000000005"
+    "Mitjana": "0.68300000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MONTERO"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "MARTÍNEZ",
-    "Mitjana": "0.627"
+    "Mitjana": "0.627",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍNEZ"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.623"
+    "Mitjana": "0.623",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2009",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "MARTÍ",
-    "Mitjana": "0.42"
+    "Mitjana": "0.42",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "MARTÍ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "J. ROVIROSA",
-    "Mitjana": "1.859"
+    "Mitjana": "1.859",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ROVIROSA"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.7709999999999999"
+    "Mitjana": "1.7709999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.5640000000000001"
+    "Mitjana": "1.5640000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "R. GRAU",
-    "Mitjana": "1.5589999999999999"
+    "Mitjana": "1.5589999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.363"
+    "Mitjana": "1.363",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "1.333"
+    "Mitjana": "1.333",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.3009999999999999"
+    "Mitjana": "1.3009999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "1.3009999999999999"
+    "Mitjana": "1.3009999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "J. SELGAS",
-    "Mitjana": "1.254"
+    "Mitjana": "1.254",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "A. ALUJA",
-    "Mitjana": "1.222"
+    "Mitjana": "1.222",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. ALUJA"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "P. SERRA",
-    "Mitjana": "1.198"
+    "Mitjana": "1.198",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "M. PALAU",
-    "Mitjana": "1.1970000000000001"
+    "Mitjana": "1.1970000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PALAU"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "R. JARQUE",
-    "Mitjana": "1.181"
+    "Mitjana": "1.181",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.1739999999999999"
+    "Mitjana": "1.1739999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "1.105"
+    "Mitjana": "1.105",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "R. COLOM",
-    "Mitjana": "1.085"
+    "Mitjana": "1.085",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "1.0629999999999999"
+    "Mitjana": "1.0629999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "1.0589999999999999"
+    "Mitjana": "1.0589999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "1.0309999999999999"
+    "Mitjana": "1.0309999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "J. GRIÑÓ",
-    "Mitjana": "1"
+    "Mitjana": "1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GRIÑÓ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.86799999999999999"
+    "Mitjana": "0.86799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.86399999999999999"
+    "Mitjana": "0.86399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.81799999999999995"
+    "Mitjana": "0.81799999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "J. MIR",
-    "Mitjana": "0.79600000000000004"
+    "Mitjana": "0.79600000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MIR"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "M. ALMIRALL",
-    "Mitjana": "0.79300000000000004"
+    "Mitjana": "0.79300000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. ALMIRALL"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.78300000000000003"
+    "Mitjana": "0.78300000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "M. PRAT",
-    "Mitjana": "0.77500000000000002"
+    "Mitjana": "0.77500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PRAT"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "M.L. MALLACH",
-    "Mitjana": "0.752"
+    "Mitjana": "0.752",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.L. MALLACH"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "29",
     "Jugador": "M. GIMENO",
-    "Mitjana": "0.73099999999999998"
+    "Mitjana": "0.73099999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GIMENO"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "30",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.72099999999999997"
+    "Mitjana": "0.72099999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "31",
     "Jugador": "F. GÓMEZ",
-    "Mitjana": "0.69299999999999995"
+    "Mitjana": "0.69299999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. GÓMEZ"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "32",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.65900000000000003"
+    "Mitjana": "0.65900000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "33",
     "Jugador": "P. BALLESTER",
-    "Mitjana": "0.64900000000000002"
+    "Mitjana": "0.64900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. BALLESTER"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "34",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.42399999999999999"
+    "Mitjana": "0.42399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2011",
     "Modalitat": "LLIURE",
     "Posició": "35",
     "Jugador": "A. MARTÍ",
-    "Mitjana": "0.32200000000000001"
+    "Mitjana": "0.32200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍ"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.726"
+    "Mitjana": "1.726",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.5149999999999999"
+    "Mitjana": "1.5149999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.4590000000000001"
+    "Mitjana": "1.4590000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "1.3220000000000001"
+    "Mitjana": "1.3220000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "R. COLOM",
-    "Mitjana": "1.2589999999999999"
+    "Mitjana": "1.2589999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. COLOM"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "A. PORTA",
-    "Mitjana": "1.19"
+    "Mitjana": "1.19",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. PORTA"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "1.1879999999999999"
+    "Mitjana": "1.1879999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "J. SELGAS",
-    "Mitjana": "1.014"
+    "Mitjana": "1.014",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "E. GIRÓ",
-    "Mitjana": "0.97499999999999998"
+    "Mitjana": "0.97499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. GIRÓ"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.96399999999999997"
+    "Mitjana": "0.96399999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.94199999999999995"
+    "Mitjana": "0.94199999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.90300000000000002"
+    "Mitjana": "0.90300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.90300000000000002"
+    "Mitjana": "0.90300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.88400000000000001"
+    "Mitjana": "0.88400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.86299999999999999"
+    "Mitjana": "0.86299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "P. SERRA",
-    "Mitjana": "0.85299999999999998"
+    "Mitjana": "0.85299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "F. GÓMEZ",
-    "Mitjana": "0.82599999999999996"
+    "Mitjana": "0.82599999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. GÓMEZ"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.76300000000000001"
+    "Mitjana": "0.76300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.73599999999999999"
+    "Mitjana": "0.73599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "M. PRAT",
-    "Mitjana": "0.72199999999999998"
+    "Mitjana": "0.72199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PRAT"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "J. MIR",
-    "Mitjana": "0.70899999999999996"
+    "Mitjana": "0.70899999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MIR"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.61"
+    "Mitjana": "0.61",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.6"
+    "Mitjana": "0.6",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2012",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.252"
+    "Mitjana": "0.252",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "2.0129999999999999"
+    "Mitjana": "2.0129999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "J. SELGA",
-    "Mitjana": "1.845"
+    "Mitjana": "1.845",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGA"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.6990000000000001"
+    "Mitjana": "1.6990000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.5569999999999999"
+    "Mitjana": "1.5569999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "J. COMAS",
-    "Mitjana": "1.417"
+    "Mitjana": "1.417",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "J. SELGAS",
-    "Mitjana": "1.3660000000000001"
+    "Mitjana": "1.3660000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "1.296"
+    "Mitjana": "1.296",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "R. GRAU",
-    "Mitjana": "1.1879999999999999"
+    "Mitjana": "1.1879999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "A. PORTA",
-    "Mitjana": "1.163"
+    "Mitjana": "1.163",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. PORTA"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "1.163"
+    "Mitjana": "1.163",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "1.093"
+    "Mitjana": "1.093",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "1.073"
+    "Mitjana": "1.073",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "X. FINA",
-    "Mitjana": "1.034"
+    "Mitjana": "1.034",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "P. SERRA",
-    "Mitjana": "1.01"
+    "Mitjana": "1.01",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.94199999999999995"
+    "Mitjana": "0.94199999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.88800000000000001"
+    "Mitjana": "0.88800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.86199999999999999"
+    "Mitjana": "0.86199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.80600000000000005"
+    "Mitjana": "0.80600000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.8"
+    "Mitjana": "0.8",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.79800000000000004"
+    "Mitjana": "0.79800000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.75900000000000001"
+    "Mitjana": "0.75900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.746"
+    "Mitjana": "0.746",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.74399999999999999"
+    "Mitjana": "0.74399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.69899999999999995"
+    "Mitjana": "0.69899999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "M. BRUQUETAS",
-    "Mitjana": "0.56799999999999995"
+    "Mitjana": "0.56799999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. BRUQUETAS"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.55000000000000004"
+    "Mitjana": "0.55000000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.54100000000000004"
+    "Mitjana": "0.54100000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "J. ARMENGOL",
-    "Mitjana": "0.52300000000000002"
+    "Mitjana": "0.52300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ARMENGOL"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "29",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.497"
+    "Mitjana": "0.497",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "30",
     "Jugador": "P. BALLESTER",
-    "Mitjana": "0.44600000000000001"
+    "Mitjana": "0.44600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. BALLESTER"
   },
   {
     "Any": "2013",
     "Modalitat": "LLIURE",
     "Posició": "31",
     "Jugador": "J. MONTERO",
-    "Mitjana": "0.443"
+    "Mitjana": "0.443",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MONTERO"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "2.125"
+    "Mitjana": "2.125",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "V. HAMMER",
-    "Mitjana": "2.117"
+    "Mitjana": "2.117",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. HAMMER"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "2.0920000000000001"
+    "Mitjana": "2.0920000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.7070000000000001"
+    "Mitjana": "1.7070000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "J. GELABERT",
-    "Mitjana": "1.556"
+    "Mitjana": "1.556",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "J. COMAS",
-    "Mitjana": "1.5009999999999999"
+    "Mitjana": "1.5009999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "E. LUENGO",
-    "Mitjana": "1.415"
+    "Mitjana": "1.415",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LUENGO"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "X. FINA",
-    "Mitjana": "1.1890000000000001"
+    "Mitjana": "1.1890000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "1.1850000000000001"
+    "Mitjana": "1.1850000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "A. CAMPILLO",
-    "Mitjana": "1.1779999999999999"
+    "Mitjana": "1.1779999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CAMPILLO"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "1.1599999999999999"
+    "Mitjana": "1.1599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "1.1559999999999999"
+    "Mitjana": "1.1559999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "1.153"
+    "Mitjana": "1.153",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "E. RODRÍGUEZ",
-    "Mitjana": "1.127"
+    "Mitjana": "1.127",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. RODRÍGUEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "1.119"
+    "Mitjana": "1.119",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "1.103"
+    "Mitjana": "1.103",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "1.099"
+    "Mitjana": "1.099",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "J. SELGAS",
-    "Mitjana": "1.097"
+    "Mitjana": "1.097",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "J.M. SOMS",
-    "Mitjana": "0.91"
+    "Mitjana": "0.91",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. SOMS"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "J. FERNÁNDEZ",
-    "Mitjana": "0.88800000000000001"
+    "Mitjana": "0.88800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FERNÁNDEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.77900000000000003"
+    "Mitjana": "0.77900000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.754"
+    "Mitjana": "0.754",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.71599999999999997"
+    "Mitjana": "0.71599999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.71499999999999997"
+    "Mitjana": "0.71499999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.70099999999999996"
+    "Mitjana": "0.70099999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "J.M. VIAPLANA",
-    "Mitjana": "0.69199999999999995"
+    "Mitjana": "0.69199999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VIAPLANA"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.67600000000000005"
+    "Mitjana": "0.67600000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "S. MARÍN",
-    "Mitjana": "0.64800000000000002"
+    "Mitjana": "0.64800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. MARÍN"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "29",
     "Jugador": "J. ARMENGOL",
-    "Mitjana": "0.59599999999999997"
+    "Mitjana": "0.59599999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ARMENGOL"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "30",
     "Jugador": "J. MIR",
-    "Mitjana": "0.59299999999999997"
+    "Mitjana": "0.59299999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MIR"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "31",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.51100000000000001"
+    "Mitjana": "0.51100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2014",
     "Modalitat": "LLIURE",
     "Posició": "32",
     "Jugador": "R. BURÉS",
-    "Mitjana": "0.35899999999999999"
+    "Mitjana": "0.35899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. BURÉS"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "1.9410000000000001"
+    "Mitjana": "1.9410000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "I. HERNÁNDEZ",
-    "Mitjana": "1.5449999999999999"
+    "Mitjana": "1.5449999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. HERNÁNDEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "J. COMAS",
-    "Mitjana": "1.526"
+    "Mitjana": "1.526",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "A. MELGAREJO",
-    "Mitjana": "1.3120000000000001"
+    "Mitjana": "1.3120000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MELGAREJO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "1.296"
+    "Mitjana": "1.296",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "A. BOIX",
-    "Mitjana": "1.236"
+    "Mitjana": "1.236",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "1.2270000000000001"
+    "Mitjana": "1.2270000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "1.224"
+    "Mitjana": "1.224",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "R. MORENO",
-    "Mitjana": "1.1950000000000001"
+    "Mitjana": "1.1950000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "1.087"
+    "Mitjana": "1.087",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "A. TRILLO",
-    "Mitjana": "1.0189999999999999"
+    "Mitjana": "1.0189999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. TRILLO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.90500000000000003"
+    "Mitjana": "0.90500000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "0.90200000000000002"
+    "Mitjana": "0.90200000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.86899999999999999"
+    "Mitjana": "0.86899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.83799999999999997"
+    "Mitjana": "0.83799999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.77"
+    "Mitjana": "0.77",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.74299999999999999"
+    "Mitjana": "0.74299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.72299999999999998"
+    "Mitjana": "0.72299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.70699999999999996"
+    "Mitjana": "0.70699999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "J. IBÁÑEZ",
-    "Mitjana": "0.63900000000000001"
+    "Mitjana": "0.63900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. IBÁÑEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.63600000000000001"
+    "Mitjana": "0.63600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "D. CORBALÁN",
-    "Mitjana": "0.63200000000000001"
+    "Mitjana": "0.63200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "D. CORBALÁN"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "P. FERRÀS",
-    "Mitjana": "0.61499999999999999"
+    "Mitjana": "0.61499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. FERRÀS"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "A. DEL RIO",
-    "Mitjana": "0.61399999999999999"
+    "Mitjana": "0.61399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. DEL RIO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.60299999999999998"
+    "Mitjana": "0.60299999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "J. CABRÉ",
-    "Mitjana": "0.59"
+    "Mitjana": "0.59",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CABRÉ"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "F. LEDO",
-    "Mitjana": "0.57799999999999996"
+    "Mitjana": "0.57799999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. LEDO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.53700000000000003"
+    "Mitjana": "0.53700000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "29",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.51800000000000002"
+    "Mitjana": "0.51800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "30",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.503"
+    "Mitjana": "0.503",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "31",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.498"
+    "Mitjana": "0.498",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "32",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.48499999999999999"
+    "Mitjana": "0.48499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "33",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.443"
+    "Mitjana": "0.443",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "34",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.42299999999999999"
+    "Mitjana": "0.42299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "35",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.4"
+    "Mitjana": "0.4",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "36",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.38900000000000001"
+    "Mitjana": "0.38900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2022",
     "Modalitat": "LLIURE",
     "Posició": "37",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.35199999999999998"
+    "Mitjana": "0.35199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "2.0070000000000001"
+    "Mitjana": "2.0070000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "E. LEÓN",
-    "Mitjana": "1.6479999999999999"
+    "Mitjana": "1.6479999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "1.37"
+    "Mitjana": "1.37",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "P. RUIZ",
-    "Mitjana": "1.349"
+    "Mitjana": "1.349",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. RUIZ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "R. MORENO",
-    "Mitjana": "1.2709999999999999"
+    "Mitjana": "1.2709999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "J. COMAS",
-    "Mitjana": "1.2450000000000001"
+    "Mitjana": "1.2450000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "1.2390000000000001"
+    "Mitjana": "1.2390000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "1.214"
+    "Mitjana": "1.214",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "A. BOIX",
-    "Mitjana": "1.19"
+    "Mitjana": "1.19",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "A. TRILLO",
-    "Mitjana": "1.1000000000000001"
+    "Mitjana": "1.1000000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. TRILLO"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.98199999999999998"
+    "Mitjana": "0.98199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.94299999999999995"
+    "Mitjana": "0.94299999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "0.93100000000000005"
+    "Mitjana": "0.93100000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.88800000000000001"
+    "Mitjana": "0.88800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.79600000000000004"
+    "Mitjana": "0.79600000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.78"
+    "Mitjana": "0.78",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.77900000000000003"
+    "Mitjana": "0.77900000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.77500000000000002"
+    "Mitjana": "0.77500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "F. LEDO",
-    "Mitjana": "0.752"
+    "Mitjana": "0.752",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. LEDO"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.73699999999999999"
+    "Mitjana": "0.73699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.68799999999999994"
+    "Mitjana": "0.68799999999999994",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.68100000000000005"
+    "Mitjana": "0.68100000000000005",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.67500000000000004"
+    "Mitjana": "0.67500000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "J. ROYES",
-    "Mitjana": "0.65700000000000003"
+    "Mitjana": "0.65700000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ROYES"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "J. IBÁÑEZ",
-    "Mitjana": "0.64700000000000002"
+    "Mitjana": "0.64700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. IBÁÑEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.61899999999999999"
+    "Mitjana": "0.61899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.58699999999999997"
+    "Mitjana": "0.58699999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "A. MEDINA",
-    "Mitjana": "0.57799999999999996"
+    "Mitjana": "0.57799999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MEDINA"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "29",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.56399999999999995"
+    "Mitjana": "0.56399999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "30",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.49199999999999999"
+    "Mitjana": "0.49199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "31",
     "Jugador": "E. ROYES",
-    "Mitjana": "0.49"
+    "Mitjana": "0.49",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. ROYES"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "32",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.47899999999999998"
+    "Mitjana": "0.47899999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "33",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.432"
+    "Mitjana": "0.432",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "34",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.42499999999999999"
+    "Mitjana": "0.42499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2023",
     "Modalitat": "LLIURE",
     "Posició": "35",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.35499999999999998"
+    "Mitjana": "0.35499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "2.2850000000000001"
+    "Mitjana": "2.2850000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "1.897"
+    "Mitjana": "1.897",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "I. HERNÁNDEZ",
-    "Mitjana": "1.5469999999999999"
+    "Mitjana": "1.5469999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. HERNÁNDEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "J. COMAS",
-    "Mitjana": "1.4339999999999999"
+    "Mitjana": "1.4339999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "R. MORENO",
-    "Mitjana": "1.3939999999999999"
+    "Mitjana": "1.3939999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "1.359"
+    "Mitjana": "1.359",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "A. BOIX",
-    "Mitjana": "1.262"
+    "Mitjana": "1.262",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "A. GÓMEZ",
-    "Mitjana": "1.167"
+    "Mitjana": "1.167",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. GÓMEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "1.077"
+    "Mitjana": "1.077",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "1.0289999999999999"
+    "Mitjana": "1.0289999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "J.L. ROSERÓ",
-    "Mitjana": "0.95899999999999996"
+    "Mitjana": "0.95899999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ROSERÓ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.875"
+    "Mitjana": "0.875",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.79800000000000004"
+    "Mitjana": "0.79800000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.78200000000000003"
+    "Mitjana": "0.78200000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.77500000000000002"
+    "Mitjana": "0.77500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.76100000000000001"
+    "Mitjana": "0.76100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.71399999999999997"
+    "Mitjana": "0.71399999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "J. IBÁÑEZ",
-    "Mitjana": "0.69299999999999995"
+    "Mitjana": "0.69299999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. IBÁÑEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "A. MEDINA",
-    "Mitjana": "0.63800000000000001"
+    "Mitjana": "0.63800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MEDINA"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.627"
+    "Mitjana": "0.627",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.60199999999999998"
+    "Mitjana": "0.60199999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.57599999999999996"
+    "Mitjana": "0.57599999999999996",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.56899999999999995"
+    "Mitjana": "0.56899999999999995",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.54800000000000004"
+    "Mitjana": "0.54800000000000004",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "A. FERNÁNDEZ",
-    "Mitjana": "0.496"
+    "Mitjana": "0.496",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. FERNÁNDEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.48799999999999999"
+    "Mitjana": "0.48799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.47099999999999997"
+    "Mitjana": "0.47099999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.46899999999999997"
+    "Mitjana": "0.46899999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "29",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.44700000000000001"
+    "Mitjana": "0.44700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "30",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.39800000000000002"
+    "Mitjana": "0.39800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "31",
     "Jugador": "E. ROYES",
-    "Mitjana": "0.39600000000000002"
+    "Mitjana": "0.39600000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. ROYES"
   },
   {
     "Any": "2024",
     "Modalitat": "LLIURE",
     "Posició": "32",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.32500000000000001"
+    "Mitjana": "0.32500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "1",
     "Jugador": "L. CHUECOS",
-    "Mitjana": "1.907590759075908"
+    "Mitjana": "1.907590759075908",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. CHUECOS"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "2",
     "Jugador": "A. BERMEJO",
-    "Mitjana": "1.8191489361702129"
+    "Mitjana": "1.8191489361702129",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BERMEJO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "3",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "1.7362318840579709"
+    "Mitjana": "1.7362318840579709",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "4",
     "Jugador": "J. COMAS",
-    "Mitjana": "1.5171339563862929"
+    "Mitjana": "1.5171339563862929",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "5",
     "Jugador": "J. VILA",
-    "Mitjana": "1.3693181818181821"
+    "Mitjana": "1.3693181818181821",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VILA"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "6",
     "Jugador": "A. GÓMEZ",
-    "Mitjana": "1.3442136498516319"
+    "Mitjana": "1.3442136498516319",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. GÓMEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "7",
     "Jugador": "J.M. CAMPOS",
-    "Mitjana": "1.323809523809524"
+    "Mitjana": "1.323809523809524",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CAMPOS"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "8",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "1.288095238095238"
+    "Mitjana": "1.288095238095238",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "9",
     "Jugador": "R. MORENO",
-    "Mitjana": "1.194379391100703"
+    "Mitjana": "1.194379391100703",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "10",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "1.177033492822966"
+    "Mitjana": "1.177033492822966",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "11",
     "Jugador": "E. LUENGO",
-    "Mitjana": "1.1526881720430111"
+    "Mitjana": "1.1526881720430111",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LUENGO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "12",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "1.06029106029106"
+    "Mitjana": "1.06029106029106",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "13",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.92768079800498748"
+    "Mitjana": "0.92768079800498748",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "14",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.92601431980906923"
+    "Mitjana": "0.92601431980906923",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "15",
     "Jugador": "J.L. ROSERÓ",
-    "Mitjana": "0.92074592074592077"
+    "Mitjana": "0.92074592074592077",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ROSERÓ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "16",
     "Jugador": "A. FUENTES",
-    "Mitjana": "0.84082397003745324"
+    "Mitjana": "0.84082397003745324",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. FUENTES"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "17",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.79400749063670417"
+    "Mitjana": "0.79400749063670417",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "18",
     "Jugador": "J. IBÁÑEZ",
-    "Mitjana": "0.77229601518026569"
+    "Mitjana": "0.77229601518026569",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. IBÁÑEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "19",
     "Jugador": "J. SÁNCHEZ",
-    "Mitjana": "0.7609108159392789"
+    "Mitjana": "0.7609108159392789",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SÁNCHEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "20",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.75506445672191524"
+    "Mitjana": "0.75506445672191524",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "21",
     "Jugador": "A. MEDINA",
-    "Mitjana": "0.73643410852713176"
+    "Mitjana": "0.73643410852713176",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MEDINA"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "22",
     "Jugador": "E. GARCÍA",
-    "Mitjana": "0.73482428115015974"
+    "Mitjana": "0.73482428115015974",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. GARCÍA"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "23",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.71224489795918366"
+    "Mitjana": "0.71224489795918366",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "24",
     "Jugador": "M. GONZALVO",
-    "Mitjana": "0.70436187399030692"
+    "Mitjana": "0.70436187399030692",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. GONZALVO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "25",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.7032755298651252"
+    "Mitjana": "0.7032755298651252",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "26",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.68204283360790774"
+    "Mitjana": "0.68204283360790774",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "27",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.68097014925373134"
+    "Mitjana": "0.68097014925373134",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "28",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.67632850241545894"
+    "Mitjana": "0.67632850241545894",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "29",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.6741573033707865"
+    "Mitjana": "0.6741573033707865",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "30",
     "Jugador": "J. GÓMEZ",
-    "Mitjana": "0.66771159874608155"
+    "Mitjana": "0.66771159874608155",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GÓMEZ"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "31",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.62180579216354348"
+    "Mitjana": "0.62180579216354348",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "32",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.60917721518987344"
+    "Mitjana": "0.60917721518987344",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "33",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.59966499162479059"
+    "Mitjana": "0.59966499162479059",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "34",
     "Jugador": "P. FERRÀS",
-    "Mitjana": "0.58557046979865768"
+    "Mitjana": "0.58557046979865768",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. FERRÀS"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "35",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.53355704697986572"
+    "Mitjana": "0.53355704697986572",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "36",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.52307692307692311"
+    "Mitjana": "0.52307692307692311",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "37",
     "Jugador": "S. MARÍN",
-    "Mitjana": "0.50363636363636366"
+    "Mitjana": "0.50363636363636366",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. MARÍN"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "38",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.49"
+    "Mitjana": "0.49",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "39",
     "Jugador": "A. MORA",
-    "Mitjana": "0.46790540540540537"
+    "Mitjana": "0.46790540540540537",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MORA"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "40",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.41666666666666669"
+    "Mitjana": "0.41666666666666669",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "41",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.41442953020134232"
+    "Mitjana": "0.41442953020134232",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2025",
     "Modalitat": "LLIURE",
     "Posició": "42",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.37454545454545463"
+    "Mitjana": "0.37454545454545463",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.46300000000000002"
+    "Mitjana": "0.46300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.38300000000000001"
+    "Mitjana": "0.38300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.34300000000000003"
+    "Mitjana": "0.34300000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "R. GRAU",
-    "Mitjana": "0.34"
+    "Mitjana": "0.34",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. GRAU"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.32600000000000001"
+    "Mitjana": "0.32600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.32400000000000001"
+    "Mitjana": "0.32400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.32300000000000001"
+    "Mitjana": "0.32300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "E. RODRÍGUEZ",
-    "Mitjana": "0.315"
+    "Mitjana": "0.315",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. RODRÍGUEZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.30499999999999999"
+    "Mitjana": "0.30499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.28799999999999998"
+    "Mitjana": "0.28799999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.28499999999999998"
+    "Mitjana": "0.28499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.27600000000000002"
+    "Mitjana": "0.27600000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.27400000000000002"
+    "Mitjana": "0.27400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.26300000000000001"
+    "Mitjana": "0.26300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "J.M. VAL",
-    "Mitjana": "0.25900000000000001"
+    "Mitjana": "0.25900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VAL"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "X. FINA",
-    "Mitjana": "0.251"
+    "Mitjana": "0.251",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.224"
+    "Mitjana": "0.224",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.223"
+    "Mitjana": "0.223",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.219"
+    "Mitjana": "0.219",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "A. POMETTI",
-    "Mitjana": "0.19700000000000001"
+    "Mitjana": "0.19700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. POMETTI"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.187"
+    "Mitjana": "0.187",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "A. CAMPILLO",
-    "Mitjana": "0.184"
+    "Mitjana": "0.184",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CAMPILLO"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "S. BARRIS",
-    "Mitjana": "0.17599999999999999"
+    "Mitjana": "0.17599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. BARRIS"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.16800000000000001"
+    "Mitjana": "0.16800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.16400000000000001"
+    "Mitjana": "0.16400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "A. DEL RIO",
-    "Mitjana": "0.156"
+    "Mitjana": "0.156",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. DEL RIO"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.15"
+    "Mitjana": "0.15",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.15"
+    "Mitjana": "0.15",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "S. MARÍN",
-    "Mitjana": "0.14000000000000001"
+    "Mitjana": "0.14000000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "S. MARÍN"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.13700000000000001"
+    "Mitjana": "0.13700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "M. BRUQUETAS",
-    "Mitjana": "0.112"
+    "Mitjana": "0.112",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. BRUQUETAS"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.09"
+    "Mitjana": "0.09",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "R. BURÉS",
-    "Mitjana": "6.9000000000000006E-2"
+    "Mitjana": "6.9000000000000006E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. BURÉS"
   },
   {
     "Any": "2016",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "0.08"
+    "Mitjana": "0.08",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.39300000000000002"
+    "Mitjana": "0.39300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.38800000000000001"
+    "Mitjana": "0.38800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.38"
+    "Mitjana": "0.38",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.35"
+    "Mitjana": "0.35",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.33400000000000002"
+    "Mitjana": "0.33400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.314"
+    "Mitjana": "0.314",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.31"
+    "Mitjana": "0.31",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "X. FINA",
-    "Mitjana": "0.309"
+    "Mitjana": "0.309",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.29499999999999998"
+    "Mitjana": "0.29499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.28999999999999998"
+    "Mitjana": "0.28999999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "J.M. VAL",
-    "Mitjana": "0.28899999999999998"
+    "Mitjana": "0.28899999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VAL"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.27700000000000002"
+    "Mitjana": "0.27700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.27300000000000002"
+    "Mitjana": "0.27300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "J. SELGAS",
-    "Mitjana": "0.27300000000000002"
+    "Mitjana": "0.27300000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. SELGAS"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.26600000000000001"
+    "Mitjana": "0.26600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.255"
+    "Mitjana": "0.255",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "P. SOLERGIBERT",
-    "Mitjana": "0.24399999999999999"
+    "Mitjana": "0.24399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SOLERGIBERT"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "G. GIMÉNEZ",
-    "Mitjana": "0.23899999999999999"
+    "Mitjana": "0.23899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. GIMÉNEZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.23799999999999999"
+    "Mitjana": "0.23799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.23499999999999999"
+    "Mitjana": "0.23499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "J. LAHOZ",
-    "Mitjana": "0.224"
+    "Mitjana": "0.224",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. LAHOZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.22"
+    "Mitjana": "0.22",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "D. CORBALÁN",
-    "Mitjana": "0.21099999999999999"
+    "Mitjana": "0.21099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "D. CORBALÁN"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.19"
+    "Mitjana": "0.19",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "A. POMETTI",
-    "Mitjana": "0.188"
+    "Mitjana": "0.188",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. POMETTI"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.182"
+    "Mitjana": "0.182",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "F. TARÉS",
-    "Mitjana": "0.159"
+    "Mitjana": "0.159",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TARÉS"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.155"
+    "Mitjana": "0.155",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "J. GÓMEZ",
-    "Mitjana": "0.15"
+    "Mitjana": "0.15",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GÓMEZ"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "A. DEL RÍO",
-    "Mitjana": "0.13400000000000001"
+    "Mitjana": "0.13400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. DEL RÍO"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.126"
+    "Mitjana": "0.126",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "P. FERRÁS",
-    "Mitjana": "0.122"
+    "Mitjana": "0.122",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. FERRÁS"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "ESCODA",
-    "Mitjana": "0.11799999999999999"
+    "Mitjana": "0.11799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "ESCODA"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "J.M. VALLÉS",
-    "Mitjana": "9.1999999999999998E-2"
+    "Mitjana": "9.1999999999999998E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. VALLÉS"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.09"
+    "Mitjana": "0.09",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2017",
     "Modalitat": "3 BANDES",
     "Posició": "36",
     "Jugador": "R. BURÉS",
-    "Mitjana": "0.05"
+    "Mitjana": "0.05",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. BURÉS"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.441"
+    "Mitjana": "0.441",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.38500000000000001"
+    "Mitjana": "0.38500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.378"
+    "Mitjana": "0.378",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.35799999999999998"
+    "Mitjana": "0.35799999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.313"
+    "Mitjana": "0.313",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "JOAN RODRÍGUEZ",
-    "Mitjana": "0.36"
+    "Mitjana": "0.36",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "JOAN RODRÍGUEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.30099999999999999"
+    "Mitjana": "0.30099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "E.RODRÍGUEZ",
-    "Mitjana": "0.28999999999999998"
+    "Mitjana": "0.28999999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E.RODRÍGUEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "M.PAMPLONA",
-    "Mitjana": "0.28699999999999998"
+    "Mitjana": "0.28699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.PAMPLONA"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "G. RASTROLLO",
-    "Mitjana": "0.27"
+    "Mitjana": "0.27",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. RASTROLLO"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.26900000000000002"
+    "Mitjana": "0.26900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.26700000000000002"
+    "Mitjana": "0.26700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.26100000000000001"
+    "Mitjana": "0.26100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.249"
+    "Mitjana": "0.249",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.248"
+    "Mitjana": "0.248",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J.Mª VAL",
-    "Mitjana": "0.246"
+    "Mitjana": "0.246",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.Mª VAL"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "E. LAHOZ",
-    "Mitjana": "0.245"
+    "Mitjana": "0.245",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LAHOZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "D. CORBALÁN",
-    "Mitjana": "0.24399999999999999"
+    "Mitjana": "0.24399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "D. CORBALÁN"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.23300000000000001"
+    "Mitjana": "0.23300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.22800000000000001"
+    "Mitjana": "0.22800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "G.GIMÉNEZ",
-    "Mitjana": "0.21199999999999999"
+    "Mitjana": "0.21199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G.GIMÉNEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "F. TORRECILLAS",
-    "Mitjana": "0.19400000000000001"
+    "Mitjana": "0.19400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TORRECILLAS"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.19400000000000001"
+    "Mitjana": "0.19400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.187"
+    "Mitjana": "0.187",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "J.Mª SOMS",
-    "Mitjana": "0.185"
+    "Mitjana": "0.185",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.Mª SOMS"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.182"
+    "Mitjana": "0.182",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "A. DEL RÍO",
-    "Mitjana": "0.18"
+    "Mitjana": "0.18",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. DEL RÍO"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "P. SERRA",
-    "Mitjana": "0.17399999999999999"
+    "Mitjana": "0.17399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "A.TRILLO",
-    "Mitjana": "0.17100000000000001"
+    "Mitjana": "0.17100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A.TRILLO"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "A.POMETTI",
-    "Mitjana": "0.151"
+    "Mitjana": "0.151",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A.POMETTI"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "A. DÍEZ",
-    "Mitjana": "0.14599999999999999"
+    "Mitjana": "0.14599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. DÍEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "P. FERRÁS",
-    "Mitjana": "0.14599999999999999"
+    "Mitjana": "0.14599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. FERRÁS"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "J. GÓMEZ",
-    "Mitjana": "0.13700000000000001"
+    "Mitjana": "0.13700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GÓMEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "R.POLLS",
-    "Mitjana": "0.11799999999999999"
+    "Mitjana": "0.11799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R.POLLS"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.108"
+    "Mitjana": "0.108",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "36",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.1"
+    "Mitjana": "0.1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "37",
     "Jugador": "M.QUEROL",
-    "Mitjana": "7.8E-2"
+    "Mitjana": "7.8E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.QUEROL"
   },
   {
     "Any": "2018",
     "Modalitat": "3 BANDES",
     "Posició": "38",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "7.2999999999999995E-2"
+    "Mitjana": "7.2999999999999995E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.441"
+    "Mitjana": "0.441",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.38500000000000001"
+    "Mitjana": "0.38500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.378"
+    "Mitjana": "0.378",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.35799999999999998"
+    "Mitjana": "0.35799999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.313"
+    "Mitjana": "0.313",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "JOAN RODRÍGUEZ",
-    "Mitjana": "0.36"
+    "Mitjana": "0.36",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "JOAN RODRÍGUEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.30099999999999999"
+    "Mitjana": "0.30099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "E.RODRÍGUEZ",
-    "Mitjana": "0.28999999999999998"
+    "Mitjana": "0.28999999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E.RODRÍGUEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "M.PAMPLONA",
-    "Mitjana": "0.28699999999999998"
+    "Mitjana": "0.28699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.PAMPLONA"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "G. RASTROLLO",
-    "Mitjana": "0.27"
+    "Mitjana": "0.27",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G. RASTROLLO"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "J.M. RODRÍGUEZ",
-    "Mitjana": "0.26900000000000002"
+    "Mitjana": "0.26900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. RODRÍGUEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "F. BARCIA",
-    "Mitjana": "0.26700000000000002"
+    "Mitjana": "0.26700000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. BARCIA"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.26100000000000001"
+    "Mitjana": "0.26100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.249"
+    "Mitjana": "0.249",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.248"
+    "Mitjana": "0.248",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J.Mª VAL",
-    "Mitjana": "0.246"
+    "Mitjana": "0.246",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.Mª VAL"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "E. LAHOZ",
-    "Mitjana": "0.245"
+    "Mitjana": "0.245",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LAHOZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "D. CORBALÁN",
-    "Mitjana": "0.24399999999999999"
+    "Mitjana": "0.24399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "D. CORBALÁN"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.23300000000000001"
+    "Mitjana": "0.23300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.22800000000000001"
+    "Mitjana": "0.22800000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "G.GIMÉNEZ",
-    "Mitjana": "0.21199999999999999"
+    "Mitjana": "0.21199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G.GIMÉNEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "F. TORRECILLAS",
-    "Mitjana": "0.19400000000000001"
+    "Mitjana": "0.19400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. TORRECILLAS"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.19400000000000001"
+    "Mitjana": "0.19400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.187"
+    "Mitjana": "0.187",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "J.Mª SOMS",
-    "Mitjana": "0.185"
+    "Mitjana": "0.185",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.Mª SOMS"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.182"
+    "Mitjana": "0.182",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "A. DEL RÍO",
-    "Mitjana": "0.18"
+    "Mitjana": "0.18",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. DEL RÍO"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "P. SERRA",
-    "Mitjana": "0.17399999999999999"
+    "Mitjana": "0.17399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SERRA"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "A.TRILLO",
-    "Mitjana": "0.17100000000000001"
+    "Mitjana": "0.17100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A.TRILLO"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "A.POMETTI",
-    "Mitjana": "0.151"
+    "Mitjana": "0.151",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A.POMETTI"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "A. DÍEZ",
-    "Mitjana": "0.14599999999999999"
+    "Mitjana": "0.14599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. DÍEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "P. FERRÁS",
-    "Mitjana": "0.14599999999999999"
+    "Mitjana": "0.14599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. FERRÁS"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "J. GÓMEZ",
-    "Mitjana": "0.13700000000000001"
+    "Mitjana": "0.13700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GÓMEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "R.POLLS",
-    "Mitjana": "0.11799999999999999"
+    "Mitjana": "0.11799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R.POLLS"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "A. MARTÍNEZ",
-    "Mitjana": "0.108"
+    "Mitjana": "0.108",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MARTÍNEZ"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "36",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.1"
+    "Mitjana": "0.1",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "37",
     "Jugador": "M.QUEROL",
-    "Mitjana": "7.8E-2"
+    "Mitjana": "7.8E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M.QUEROL"
   },
   {
     "Any": "2019",
     "Modalitat": "3 BANDES",
     "Posició": "38",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "7.2999999999999995E-2"
+    "Mitjana": "7.2999999999999995E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.443"
+    "Mitjana": "0.443",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.39"
+    "Mitjana": "0.39",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "JOAN RODRÍGUEZ",
-    "Mitjana": "0.375"
+    "Mitjana": "0.375",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "JOAN RODRÍGUEZ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.35699999999999998"
+    "Mitjana": "0.35699999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.34899999999999998"
+    "Mitjana": "0.34899999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "A.BOIX",
-    "Mitjana": "0.33900000000000002"
+    "Mitjana": "0.33900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A.BOIX"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "X. FINA",
-    "Mitjana": "0.33100000000000002"
+    "Mitjana": "0.33100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "X. FINA"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.33100000000000002"
+    "Mitjana": "0.33100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.32400000000000001"
+    "Mitjana": "0.32400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "IG. HERNÁNDEZ",
-    "Mitjana": "0.309"
+    "Mitjana": "0.309",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "IG. HERNÁNDEZ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.30499999999999999"
+    "Mitjana": "0.30499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "P. SOLERGIBERT",
-    "Mitjana": "0.30099999999999999"
+    "Mitjana": "0.30099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. SOLERGIBERT"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "J.Mª VAL",
-    "Mitjana": "0.28799999999999998"
+    "Mitjana": "0.28799999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.Mª VAL"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.28599999999999998"
+    "Mitjana": "0.28599999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "J. GELABERT",
-    "Mitjana": "0.27800000000000002"
+    "Mitjana": "0.27800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GELABERT"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "M. ALVAREZ",
-    "Mitjana": "0.27500000000000002"
+    "Mitjana": "0.27500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. ALVAREZ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.27"
+    "Mitjana": "0.27",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "D. CORBALÁN",
-    "Mitjana": "0.23699999999999999"
+    "Mitjana": "0.23699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "D. CORBALÁN"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "A.TRILLO",
-    "Mitjana": "0.22"
+    "Mitjana": "0.22",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A.TRILLO"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "A. CASTILLO",
-    "Mitjana": "0.21"
+    "Mitjana": "0.21",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. CASTILLO"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "G.GIMÉNEZ",
-    "Mitjana": "0.20200000000000001"
+    "Mitjana": "0.20200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "G.GIMÉNEZ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.2"
+    "Mitjana": "0.2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.19700000000000001"
+    "Mitjana": "0.19700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.19600000000000001"
+    "Mitjana": "0.19600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "J.Mª SOMS",
-    "Mitjana": "0.186"
+    "Mitjana": "0.186",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.Mª SOMS"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.182"
+    "Mitjana": "0.182",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "P. FERRÁS",
-    "Mitjana": "0.18"
+    "Mitjana": "0.18",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. FERRÁS"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "M. EBRÍ",
-    "Mitjana": "0.17699999999999999"
+    "Mitjana": "0.17699999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. EBRÍ"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.16900000000000001"
+    "Mitjana": "0.16900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.121"
+    "Mitjana": "0.121",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.12"
+    "Mitjana": "0.12",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.115"
+    "Mitjana": "0.115",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "9.1999999999999998E-2"
+    "Mitjana": "9.1999999999999998E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2020",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "6.9000000000000006E-2"
+    "Mitjana": "6.9000000000000006E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.39400000000000002"
+    "Mitjana": "0.39400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.37"
+    "Mitjana": "0.37",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.34399999999999997"
+    "Mitjana": "0.34399999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.33900000000000002"
+    "Mitjana": "0.33900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.33400000000000002"
+    "Mitjana": "0.33400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.32900000000000001"
+    "Mitjana": "0.32900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "LL. GONZÁLEZ",
-    "Mitjana": "0.32300000000000001"
+    "Mitjana": "0.32300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "LL. GONZÁLEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "D. CORBALÁN",
-    "Mitjana": "0.28000000000000003"
+    "Mitjana": "0.28000000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "D. CORBALÁN"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.26800000000000002"
+    "Mitjana": "0.26800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "A. TRILLO",
-    "Mitjana": "0.249"
+    "Mitjana": "0.249",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. TRILLO"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.247"
+    "Mitjana": "0.247",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.22900000000000001"
+    "Mitjana": "0.22900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.20499999999999999"
+    "Mitjana": "0.20499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "J.M. GIBERNAU",
-    "Mitjana": "0.19900000000000001"
+    "Mitjana": "0.19900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. GIBERNAU"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.19"
+    "Mitjana": "0.19",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "A. DEL RÍO",
-    "Mitjana": "0.187"
+    "Mitjana": "0.187",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. DEL RÍO"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.17799999999999999"
+    "Mitjana": "0.17799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "R. MORENO",
-    "Mitjana": "0.17199999999999999"
+    "Mitjana": "0.17199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.154"
+    "Mitjana": "0.154",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.14399999999999999"
+    "Mitjana": "0.14399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.14000000000000001"
+    "Mitjana": "0.14000000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.13900000000000001"
+    "Mitjana": "0.13900000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "J.L. SAUCEDO",
-    "Mitjana": "0.13100000000000001"
+    "Mitjana": "0.13100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. SAUCEDO"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.12"
+    "Mitjana": "0.12",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.11799999999999999"
+    "Mitjana": "0.11799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.111"
+    "Mitjana": "0.111",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "E. LLORENTE",
-    "Mitjana": "0.106"
+    "Mitjana": "0.106",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LLORENTE"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "9.6000000000000002E-2"
+    "Mitjana": "9.6000000000000002E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "E. ROYES",
-    "Mitjana": "8.6999999999999994E-2"
+    "Mitjana": "8.6999999999999994E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. ROYES"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "M. MANZANO",
-    "Mitjana": "8.3000000000000004E-2"
+    "Mitjana": "8.3000000000000004E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "M. QUEROL",
-    "Mitjana": "8.1000000000000003E-2"
+    "Mitjana": "8.1000000000000003E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "7.4999999999999997E-2"
+    "Mitjana": "7.4999999999999997E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "6.3E-2"
+    "Mitjana": "6.3E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2021",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.39800000000000002"
+    "Mitjana": "0.39800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.52400000000000002"
+    "Mitjana": "0.52400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "J. MUÑOZ",
-    "Mitjana": "0.46"
+    "Mitjana": "0.46",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MUÑOZ"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "L. GONZÁLEZ",
-    "Mitjana": "0.33800000000000002"
+    "Mitjana": "0.33800000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "L. GONZÁLEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.33400000000000002"
+    "Mitjana": "0.33400000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.32300000000000001"
+    "Mitjana": "0.32300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.315"
+    "Mitjana": "0.315",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.28299999999999997"
+    "Mitjana": "0.28299999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "A. TRILLO",
-    "Mitjana": "0.28199999999999997"
+    "Mitjana": "0.28199999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. TRILLO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.27500000000000002"
+    "Mitjana": "0.27500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.26900000000000002"
+    "Mitjana": "0.26900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "J. MELGAREJO",
-    "Mitjana": "0.26500000000000001"
+    "Mitjana": "0.26500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. MELGAREJO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "P. ALVAREZ",
-    "Mitjana": "0.25"
+    "Mitjana": "0.25",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ALVAREZ"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "D. CORBALÁN",
-    "Mitjana": "0.24099999999999999"
+    "Mitjana": "0.24099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "D. CORBALÁN"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "R. MORENO",
-    "Mitjana": "0.23"
+    "Mitjana": "0.23",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.2"
+    "Mitjana": "0.2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.193"
+    "Mitjana": "0.193",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "J. VEZA",
-    "Mitjana": "0.193"
+    "Mitjana": "0.193",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VEZA"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.183"
+    "Mitjana": "0.183",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "V. INOCENTES",
-    "Mitjana": "0.18"
+    "Mitjana": "0.18",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "V. INOCENTES"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.17799999999999999"
+    "Mitjana": "0.17799999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "P. FERRÀS",
-    "Mitjana": "0.16700000000000001"
+    "Mitjana": "0.16700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. FERRÀS"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.16200000000000001"
+    "Mitjana": "0.16200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.161"
+    "Mitjana": "0.161",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "F. LEDO",
-    "Mitjana": "0.15"
+    "Mitjana": "0.15",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. LEDO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "J. IBAÑEZ",
-    "Mitjana": "0.14399999999999999"
+    "Mitjana": "0.14399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. IBAÑEZ"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.13700000000000001"
+    "Mitjana": "0.13700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.13500000000000001"
+    "Mitjana": "0.13500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.13400000000000001"
+    "Mitjana": "0.13400000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "A. MORA",
-    "Mitjana": "0.121"
+    "Mitjana": "0.121",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MORA"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.12"
+    "Mitjana": "0.12",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.11700000000000001"
+    "Mitjana": "0.11700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.115"
+    "Mitjana": "0.115",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.115"
+    "Mitjana": "0.115",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "9.9000000000000005E-2"
+    "Mitjana": "9.9000000000000005E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "M. QUEROL",
-    "Mitjana": "9.6000000000000002E-2"
+    "Mitjana": "9.6000000000000002E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "36",
     "Jugador": "F. ROYES",
-    "Mitjana": "8.7999999999999995E-2"
+    "Mitjana": "8.7999999999999995E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. ROYES"
   },
   {
     "Any": "2022",
     "Modalitat": "3 BANDES",
     "Posició": "37",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "8.3000000000000004E-2"
+    "Mitjana": "8.3000000000000004E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.48599999999999999"
+    "Mitjana": "0.48599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.41099999999999998"
+    "Mitjana": "0.41099999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.33"
+    "Mitjana": "0.33",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "A. MELGAREJO",
-    "Mitjana": "0.316"
+    "Mitjana": "0.316",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MELGAREJO"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.30099999999999999"
+    "Mitjana": "0.30099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "M. ALVAREZ",
-    "Mitjana": "0.28399999999999997"
+    "Mitjana": "0.28399999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. ALVAREZ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.27500000000000002"
+    "Mitjana": "0.27500000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "M. PAMPLONA",
-    "Mitjana": "0.26100000000000001"
+    "Mitjana": "0.26100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. PAMPLONA"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.26"
+    "Mitjana": "0.26",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "I. LÓPEZ",
-    "Mitjana": "0.24299999999999999"
+    "Mitjana": "0.24299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "I. LÓPEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.22600000000000001"
+    "Mitjana": "0.22600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "R. MORENO",
-    "Mitjana": "0.23300000000000001"
+    "Mitjana": "0.23300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "0.224"
+    "Mitjana": "0.224",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.218"
+    "Mitjana": "0.218",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.20899999999999999"
+    "Mitjana": "0.20899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.20899999999999999"
+    "Mitjana": "0.20899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.186"
+    "Mitjana": "0.186",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "J. VEZA",
-    "Mitjana": "0.17599999999999999"
+    "Mitjana": "0.17599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VEZA"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.17599999999999999"
+    "Mitjana": "0.17599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "J. GIBERNAU",
-    "Mitjana": "0.17"
+    "Mitjana": "0.17",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. GIBERNAU"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.16700000000000001"
+    "Mitjana": "0.16700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "J. IBAÑEZ",
-    "Mitjana": "0.156"
+    "Mitjana": "0.156",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. IBAÑEZ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.155"
+    "Mitjana": "0.155",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.14899999999999999"
+    "Mitjana": "0.14899999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.14000000000000001"
+    "Mitjana": "0.14000000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "P. FERRÀS",
-    "Mitjana": "0.13700000000000001"
+    "Mitjana": "0.13700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. FERRÀS"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.12"
+    "Mitjana": "0.12",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "0.11700000000000001"
+    "Mitjana": "0.11700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.11600000000000001"
+    "Mitjana": "0.11600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.108"
+    "Mitjana": "0.108",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.108"
+    "Mitjana": "0.108",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "0.107"
+    "Mitjana": "0.107",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.10100000000000001"
+    "Mitjana": "0.10100000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "34",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "9.7000000000000003E-2"
+    "Mitjana": "9.7000000000000003E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "35",
     "Jugador": "E. ROYES",
-    "Mitjana": "8.8999999999999996E-2"
+    "Mitjana": "8.8999999999999996E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. ROYES"
   },
   {
     "Any": "2023",
     "Modalitat": "3 BANDES",
     "Posició": "36",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "6.3E-2"
+    "Mitjana": "6.3E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "1",
     "Jugador": "A. GÓMEZ",
-    "Mitjana": "0.47499999999999998"
+    "Mitjana": "0.47499999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. GÓMEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "2",
     "Jugador": "E. LEÓN",
-    "Mitjana": "0.42399999999999999"
+    "Mitjana": "0.42399999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. LEÓN"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "3",
     "Jugador": "J.F. SANTOS",
-    "Mitjana": "0.42"
+    "Mitjana": "0.42",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.F. SANTOS"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "4",
     "Jugador": "J.M. CAMPOS",
-    "Mitjana": "0.38300000000000001"
+    "Mitjana": "0.38300000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CAMPOS"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "5",
     "Jugador": "A. BOIX",
-    "Mitjana": "0.34899999999999998"
+    "Mitjana": "0.34899999999999998",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. BOIX"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "6",
     "Jugador": "J. RODRÍGUEZ",
-    "Mitjana": "0.34200000000000003"
+    "Mitjana": "0.34200000000000003",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. RODRÍGUEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "7",
     "Jugador": "R. CERVANTES",
-    "Mitjana": "0.33900000000000002"
+    "Mitjana": "0.33900000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. CERVANTES"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "8",
     "Jugador": "A. MELGAREJO",
-    "Mitjana": "0.30299999999999999"
+    "Mitjana": "0.30299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MELGAREJO"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "9",
     "Jugador": "J. COMAS",
-    "Mitjana": "0.28299999999999997"
+    "Mitjana": "0.28299999999999997",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. COMAS"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "10",
     "Jugador": "P. ÁLVAREZ",
-    "Mitjana": "0.27100000000000002"
+    "Mitjana": "0.27100000000000002",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. ÁLVAREZ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "11",
     "Jugador": "M. SÁNCHEZ",
-    "Mitjana": "0.248"
+    "Mitjana": "0.248",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. SÁNCHEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "12",
     "Jugador": "R. MERCADER",
-    "Mitjana": "0.22700000000000001"
+    "Mitjana": "0.22700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MERCADER"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "13",
     "Jugador": "R. MORENO",
-    "Mitjana": "0.22600000000000001"
+    "Mitjana": "0.22600000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. MORENO"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "14",
     "Jugador": "P. CASANOVA",
-    "Mitjana": "0.221"
+    "Mitjana": "0.221",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "P. CASANOVA"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "15",
     "Jugador": "E. DÍAZ",
-    "Mitjana": "0.21299999999999999"
+    "Mitjana": "0.21299999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. DÍAZ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "16",
     "Jugador": "J. FITÓ",
-    "Mitjana": "0.20200000000000001"
+    "Mitjana": "0.20200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. FITÓ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "17",
     "Jugador": "J. VEZA",
-    "Mitjana": "0.20200000000000001"
+    "Mitjana": "0.20200000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VEZA"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "18",
     "Jugador": "J.A. SAUCEDO",
-    "Mitjana": "0.19"
+    "Mitjana": "0.19",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.A. SAUCEDO"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "19",
     "Jugador": "J. HERNÁNDEZ",
-    "Mitjana": "0.188"
+    "Mitjana": "0.188",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. HERNÁNDEZ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "20",
     "Jugador": "R. SOTO",
-    "Mitjana": "0.186"
+    "Mitjana": "0.186",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. SOTO"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "21",
     "Jugador": "A. MEDINA",
-    "Mitjana": "0.17599999999999999"
+    "Mitjana": "0.17599999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "A. MEDINA"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "22",
     "Jugador": "E. CURCÓ",
-    "Mitjana": "0.17499999999999999"
+    "Mitjana": "0.17499999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. CURCÓ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "23",
     "Jugador": "R. POLLS",
-    "Mitjana": "0.17199999999999999"
+    "Mitjana": "0.17199999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. POLLS"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "24",
     "Jugador": "J.L. ARROYO",
-    "Mitjana": "0.16"
+    "Mitjana": "0.16",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.L. ARROYO"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "25",
     "Jugador": "M. QUEROL",
-    "Mitjana": "0.14099999999999999"
+    "Mitjana": "0.14099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. QUEROL"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "26",
     "Jugador": "R. JARQUE",
-    "Mitjana": "0.14099999999999999"
+    "Mitjana": "0.14099999999999999",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "R. JARQUE"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "27",
     "Jugador": "E. MILLÁN",
-    "Mitjana": "0.13500000000000001"
+    "Mitjana": "0.13500000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "E. MILLÁN"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "28",
     "Jugador": "J. CARRASCO",
-    "Mitjana": "0.122"
+    "Mitjana": "0.122",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. CARRASCO"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "29",
     "Jugador": "M. MANZANO",
-    "Mitjana": "0.11700000000000001"
+    "Mitjana": "0.11700000000000001",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "M. MANZANO"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "30",
     "Jugador": "J.M. CASAMOR",
-    "Mitjana": "0.108"
+    "Mitjana": "0.108",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J.M. CASAMOR"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "31",
     "Jugador": "F. VERDUGO",
-    "Mitjana": "9.9000000000000005E-2"
+    "Mitjana": "9.9000000000000005E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "F. VERDUGO"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "32",
     "Jugador": "J. ORTIZ",
-    "Mitjana": "9.0999999999999998E-2"
+    "Mitjana": "9.0999999999999998E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. ORTIZ"
   },
   {
     "Any": "2024",
     "Modalitat": "3 BANDES",
     "Posició": "33",
     "Jugador": "J. VALLÉS",
-    "Mitjana": "8.7999999999999995E-2"
+    "Mitjana": "8.7999999999999995E-2",
+    "Soci": "",
+    "Nom": "",
+    "Cognom1": "",
+    "Cognom2": "",
+    "NomComplet": "J. VALLÉS"
   }
 ]

--- a/update_ranquing.py
+++ b/update_ranquing.py
@@ -44,7 +44,16 @@ def update():
             'Posició': cell_value(cells.get('C', ET.Element('c')), strings),
             'Jugador': cell_value(cells.get('D', ET.Element('c')), strings),
             'Mitjana': cell_value(cells.get('E', ET.Element('c')), strings),
+            'Soci': cell_value(cells.get('F', ET.Element('c')), strings),
+            'Nom': cell_value(cells.get('G', ET.Element('c')), strings),
+            'Cognom1': cell_value(cells.get('H', ET.Element('c')), strings),
+            'Cognom2': cell_value(cells.get('I', ET.Element('c')), strings),
         }
+        noms = [record.get('Nom', '').strip(),
+                record.get('Cognom1', '').strip(),
+                record.get('Cognom2', '').strip()]
+        nom_complet = ' '.join([n for n in noms if n])
+        record['NomComplet'] = nom_complet if nom_complet else record['Jugador']
         rows.append(record)
     JSON_FILE.write_text(json.dumps(rows, ensure_ascii=False, indent=2))
 


### PR DESCRIPTION
## Summary
- enrich `update_ranquing.py` to read optional membership information and build a `NomComplet` field
- display `NomComplet` in ranking table and player charts
- regenerate `ranquing.json` with the new fields

## Testing
- `python3 update_ranquing.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c71dd72c832ea7a7c738ab7afb6f