### PR TITLE
Improve responsiveness of player evolution popup

### DIFF
--- a/main.js
+++ b/main.js
@@ -234,8 +234,15 @@ function mostraEvolucioJugador(jugador, nom, modalitat) {
   }
 
   const canvas = document.getElementById('chart-canvas');
-  canvas.width = Math.min(window.innerWidth * 0.9, 800);
-  canvas.height = Math.min(window.innerHeight * 0.6, 600);
+  const vmin = Math.min(window.innerWidth, window.innerHeight);
+  const size = vmin * 0.9;
+  const chartContainer = document.getElementById('player-chart');
+  if (chartContainer) {
+    chartContainer.style.width = size + 'px';
+    chartContainer.style.maxWidth = size + 'px';
+  }
+  canvas.width = size;
+  canvas.height = size * 0.6;
 
   const title = document.getElementById('chart-title');
   if (title) {

--- a/style.css
+++ b/style.css
@@ -163,8 +163,9 @@ tr:nth-child(even) {
   padding: 1rem;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  max-width: 95%;
-  width: 95%;
+  width: 95vmin;
+  max-width: 95vmin;
+  max-height: 95vmin;
 }
 
 #player-chart h3 {


### PR DESCRIPTION
## Summary
- size player chart overlay to viewport using `vmin`
- adjust canvas dimensions dynamically based on smallest screen side

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688858b7204c832e80d9d2a953e287c4