### PR TITLE
Improve mobile scrolling for evolution chart

### DIFF
--- a/main.js
+++ b/main.js
@@ -234,8 +234,16 @@ function mostraEvolucioJugador(jugador, nom, modalitat) {
   }
 
   const canvas = document.getElementById('chart-canvas');
-  canvas.width = Math.min(window.innerWidth * 0.9, 800);
-  canvas.height = Math.min(window.innerHeight * 0.6, 600);
+  const vmin = Math.min(window.innerWidth, window.innerHeight);
+  const size = vmin * 0.9;
+  const chartContainer = document.getElementById('player-chart');
+  if (chartContainer) {
+    chartContainer.style.width = size + 'px';
+    chartContainer.style.maxWidth = size + 'px';
+  }
+  const chartWidth = Math.max(size, labels.length * 40);
+  canvas.width = chartWidth;
+  canvas.height = size * 0.6;
 
   const title = document.getElementById('chart-title');
   if (title) {

--- a/style.css
+++ b/style.css
@@ -163,8 +163,10 @@ tr:nth-child(even) {
   padding: 1rem;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  max-width: 95%;
-  width: 95%;
+  width: 95vmin;
+  max-width: 95vmin;
+  max-height: 95vmin;
+  overflow: auto;
 }
 
 #player-chart h3 {
@@ -174,8 +176,7 @@ tr:nth-child(even) {
 
 
 #player-chart canvas {
-  max-width: 100%;
-  width: 100%;
+  display: block;
   height: auto;
 }
 


### PR DESCRIPTION
## Summary
- allow overflow scrolling in chart container
- widen chart canvas when dataset is large so it can be scrolled

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688858b7204c832e80d9d2a953e287c4