### PR TITLE
Remove update controls from web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ python3 server.py
 ```
 
 Aquesta ordre arrenca un petit servidor web a `http://localhost:8000`.
-Des de la mateixa aplicació es pot actualitzar `ranquing.json` a
-partir de `Ranquing.xlsx` amb el botó **Actualitza rànquing**.
+La informació de rànquing i classificacions s'ha d'actualitzar
+externament mitjançant una aplicació d'escriptori.

--- a/index.html
+++ b/index.html
@@ -13,9 +13,7 @@
     <h1>Billar Foment Martinenc</h1>
     <div id="menu">
     <button id="btn-ranking">Veure rànquing</button>
-    <button id="btn-update">Actualitza rànquing</button>
     <button id="btn-classificacio">Veure classificacions</button>
-    <button id="btn-update-classificacio">Actualitza classificacions</button>
     <div id="filters-row" style="display:none">
       <select id="year-select"></select>
       <div id="modalitat-buttons" class="button-group">

--- a/main.js
+++ b/main.js
@@ -292,20 +292,6 @@ document.getElementById('btn-ranking').addEventListener('click', () => {
   mostraRanquing();
 });
 
-document.getElementById('btn-update').addEventListener('click', () => {
-  fetch('/update-ranking')
-    .then(res => {
-      if (!res.ok) throw new Error('Error actualitzant el r\xe0nquing');
-      return res.json();
-    })
-    .then(() => {
-      inicialitza();
-    })
-    .catch(err => {
-      console.error(err);
-      alert('No s\'ha pogut actualitzar el r\xe0nquing');
-    });
-});
 
 document.getElementById('btn-classificacio').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'none';
@@ -313,20 +299,6 @@ document.getElementById('btn-classificacio').addEventListener('click', () => {
   mostraClassificacio();
 });
 
-document.getElementById('btn-update-classificacio').addEventListener('click', () => {
-  fetch('/update-classificacions')
-    .then(res => {
-      if (!res.ok) throw new Error('Error actualitzant classificacions');
-      return res.json();
-    })
-    .then(() => {
-      inicialitza();
-    })
-    .catch(err => {
-      console.error(err);
-      alert('No s\'ha pogut actualitzar les classificacions');
-    });
-});
 
 document.getElementById('close-chart').addEventListener('click', () => {
 


### PR DESCRIPTION
## Summary
- drop 'Actualitza rànquing' and 'Actualitza classificacions' buttons
- remove associated JavaScript handlers
- clarify in README that updates are done via a desktop app

## Testing
- `python3 -m py_compile server.py update_ranquing.py update_classificacions.py`

------
https://chatgpt.com/codex/tasks/task_e_68886089df84832ebe5fe32577803b5f