### PR TITLE
Fix button labels to match Catalan plural forms

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <div id="app">
     <h1>Billar Foment Martinenc</h1>
     <div id="menu">
-    <button id="btn-ranking">Rànquing</button>
+    <button id="btn-ranking">Rànquings</button>
     <button id="btn-classificacio">Classificacions</button>
     <div id="filters-row" style="display:none">
       <select id="year-select"></select>


### PR DESCRIPTION
## Summary
- updated text for the ranking button to pluralize it properly

## Testing
- `python3 -m py_compile $(ls *.py)`

------
https://chatgpt.com/codex/tasks/task_e_688866c2c4e4832e8c1c4698fe6cd3e7