### PR TITLE
Fix player name in classification data

### DIFF
--- a/classificacions.json
+++ b/classificacions.json
@@ -4084,7 +4084,7 @@
     "Modalitat": "3 BANDES",
     "Categoria": "2a",
     "Posició": "4",
-    "Jugador": "JUAN RODRÍGUEZ",
+    "Jugador": "J.M. RODRÍGUEZ",
     "Punts": "14",
     "Caramboles": "113",
     "Entrades": "586",


### PR DESCRIPTION
## Summary
- correct player name in `classificacions.json` from JUAN RODRÍGUEZ to J.M. RODRÍGUEZ

## Testing
- `python3 -m py_compile server.py update_classificacions.py update_ranquing.py`

------
https://chatgpt.com/codex/tasks/task_e_6889d9959f98832ea30031ec3772a814