### PR TITLE
Add daily events JSON generation workflow

### DIFF
--- a/.github/workflows/update-events.yml
+++ b/.github/workflows/update-events.yml
@@ -1,0 +1,34 @@
+name: Update events JSON
+
+on:
+  schedule:
+    - cron: '0 19 * * *'
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install gspread google-auth
+      - name: Write service account key
+        run: echo "$GOOGLE_SERVICE_ACCOUNT_KEY" > /tmp/sa.json
+        shell: bash
+        env:
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+      - name: Run generate script
+        run: python scripts/generate_events_json.py
+      - name: Commit and push if changed
+        run: |
+          if [[ `git status --porcelain public/events.json` ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add public/events.json
+            git commit -m "Update events.json" || true
+            git push
+          fi
+        shell: bash


### PR DESCRIPTION
## Summary
- schedule a workflow daily to generate events JSON
- install dependencies, write service account key, run generator script
- auto-commit and push if `public/events.json` changed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b91411bec832eaec37500f66aef56