### PR TITLE
Add Google Sheet events extractor

### DIFF
--- a/scripts/generate_events_json.py
+++ b/scripts/generate_events_json.py
@@ -1,0 +1,37 @@
+import json
+from datetime import datetime
+from pathlib import Path
+import gspread
+
+SA_FILENAME = '/tmp/sa.json'
+SPREADSHEET_ID = '10HIcmcf5CAqB2OAiKEqb49djG9ysu-1koxvRmrwT-Fk'
+WORKSHEET_NAME = 'Agenda'
+OUTPUT_FILE = Path('events.json')
+
+def generate():
+    gc = gspread.service_account(filename=SA_FILENAME)
+    sh = gc.open_by_key(SPREADSHEET_ID)
+    ws = sh.worksheet(WORKSHEET_NAME)
+    rows = ws.get_all_values()[1:]
+    events = []
+    for row in rows:
+        if not any(row):
+            continue
+        date_str = row[0].strip()
+        if not date_str:
+            continue
+        hour = row[1].strip() if len(row) > 1 else ''
+        title = row[2].strip() if len(row) > 2 else ''
+        date_iso = datetime.strptime(date_str, '%d/%m/%Y').date().isoformat()
+        event = {
+            'date': date_iso,
+            'title': title,
+            'allDay': not hour,
+        }
+        if hour:
+            event['time'] = hour
+        events.append(event)
+    OUTPUT_FILE.write_text(json.dumps(events, ensure_ascii=False, indent=2))
+
+if __name__ == '__main__':
+    generate()


### PR DESCRIPTION
## Summary
- create a new `scripts` folder
- add `generate_events_json.py` to pull the Agenda worksheet from the specified Google Sheets document and write `events.json`

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b915b4ba0832e94c680f2a76f4117