### PR TITLE
Add agenda front-end module

### DIFF
--- a/events.json
+++ b/events.json
@@ -1,0 +1,7 @@
+[
+  {"date": "2024-04-01", "title": "Torneig Primavera"},
+  {"date": "2024-04-05", "title": "Partida amistosa"},
+  {"date": "2024-04-12", "title": "Campionat local"},
+  {"date": "2024-04-16", "title": "Entrenament especial"},
+  {"date": "2024-04-22", "title": "Final de temporada"}
+]

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     <!-- aquí es poden afegir més botons en el futur -->
     </div>
     <div id="content"></div>
+    <div id="agenda-list"></div>
   </div>
 
 
@@ -50,5 +51,6 @@
     </div>
   </div>
   <script src="main.js"></script>
+  <script type="module" src="public/js/agenda.js"></script>
   </body>
 </html>

--- a/public/js/agenda.js
+++ b/public/js/agenda.js
@@ -1,0 +1,51 @@
+export async function loadAgenda() {
+  try {
+    const res = await fetch('/events.json');
+    if (!res.ok) throw new Error('Network response was not ok');
+    const events = await res.json();
+
+    // Convert current date to Europe/Madrid timezone
+    const now = new Date();
+    const tzNow = new Date(now.toLocaleString('en-US', { timeZone: 'Europe/Madrid' }));
+
+    // Determine Monday of this week
+    const day = tzNow.getDay(); // Sunday=0
+    const diffToMonday = day === 0 ? -6 : 1 - day;
+    const monday = new Date(tzNow);
+    monday.setDate(tzNow.getDate() + diffToMonday);
+    monday.setHours(0, 0, 0, 0);
+
+    // Sunday of next week
+    const end = new Date(monday);
+    end.setDate(monday.getDate() + 13);
+    end.setHours(23, 59, 59, 999);
+
+    const filtered = events.filter(ev => {
+      const evDate = new Date(ev.date + 'T00:00:00');
+      return evDate >= monday && evDate <= end;
+    });
+
+    const container = document.getElementById('agenda-list');
+    if (!container) return;
+    container.innerHTML = '';
+    if (!filtered.length) {
+      container.textContent = 'No hi ha esdeveniments pròxims';
+      return;
+    }
+    const ul = document.createElement('ul');
+    filtered.sort((a, b) => new Date(a.date) - new Date(b.date));
+    filtered.forEach(ev => {
+      const li = document.createElement('li');
+      const dateObj = new Date(ev.date + 'T00:00:00');
+      const formatted = dateObj.toLocaleDateString('ca-ES', { timeZone: 'Europe/Madrid', weekday: 'long', day: '2-digit', month: '2-digit' });
+      li.textContent = `${formatted} - ${ev.title}`;
+      ul.appendChild(li);
+    });
+    container.appendChild(ul);
+  } catch (err) {
+    console.error('Error loading agenda', err);
+  }
+}
+
+// Auto-load when script is included
+loadAgenda();

--- a/service-worker.js
+++ b/service-worker.js
@@ -10,8 +10,10 @@ self.addEventListener('install', event => {
         'https://cdn.jsdelivr.net/npm/chart.js',
         './ranquing.json',
         './classificacions.json',
+        './events.json',
         './icons/icon-192.png',
-        './icons/icon-512.png'
+        './icons/icon-512.png',
+        './public/js/agenda.js'
       ])
     )
   );


### PR DESCRIPTION
## Summary
- add sample `events.json`
- create `public/js/agenda.js` module to load next events
- display agenda in `index.html`
- cache agenda assets in service worker

## Testing
- `python3 -m py_compile server.py update_ranquing.py update_classificacions.py`
- `node -e "import('./public/js/agenda.js').then(m=>console.log('loaded',typeof m.loadAgenda));" 2>&1 | head` *(fails: Failed to parse URL from /events.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b917f9f14832e8eb94de3780483b1