### PR TITLE
Add agenda rendering

### DIFF
--- a/agenda.js
+++ b/agenda.js
@@ -1,0 +1,38 @@
+export async function renderAgenda() {
+  const cont = document.getElementById('agenda');
+  if (!cont) return;
+  cont.textContent = 'Carregant...';
+
+  try {
+    const res = await fetch('agenda.json');
+    if (!res.ok) throw new Error('Bad response');
+    const events = await res.json();
+
+    if (!Array.isArray(events) || events.length === 0) {
+      cont.textContent = 'No hi ha esdeveniments.';
+      return;
+    }
+
+    const fmt = new Intl.DateTimeFormat('ca-ES', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    });
+
+    const ul = document.createElement('ul');
+    for (const ev of events) {
+      const li = document.createElement('li');
+      const when = new Date(ev.date || ev.data || ev.start || ev.inici);
+      const title = ev.name || ev.titol || ev.summary || '';
+      li.textContent = `${fmt.format(when)} - ${title}`;
+      ul.appendChild(li);
+    }
+    cont.innerHTML = '';
+    cont.appendChild(ul);
+  } catch (err) {
+    console.error('Error carregant agenda', err);
+    cont.textContent = 'No hi ha esdeveniments.';
+  }
+}
+
+renderAgenda();

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     <!-- aquí es poden afegir més botons en el futur -->
     </div>
     <div id="content"></div>
+    <div id="agenda"></div>
   </div>
 
 
@@ -50,5 +51,6 @@
     </div>
   </div>
   <script src="main.js"></script>
+  <script type="module" src="agenda.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -216,3 +216,20 @@ tr:nth-child(even) {
   text-decoration: underline;
 }
 
+#agenda {
+  margin-top: 1rem;
+}
+
+#agenda ul {
+  list-style: none;
+  padding: 0;
+}
+
+#agenda li {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- add agenda display container and script
- style event list
- show events from agenda.json using ca-ES date format

## Testing
- `node --check agenda.js`


------
https://chatgpt.com/codex/tasks/task_e_688b919b371c832e9f5edf6625b492a1