### PR TITLE
Add agenda feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,9 @@ python3 server.py
 
 Aquesta ordre arrenca un petit servidor web a `http://localhost:8000`.
 La informació de rànquing i classificacions s'ha d'actualitzar
-externament mitjançant una aplicació d'escriptori.
+externament mitjançant una aplicació d'escriptori. De la mateixa manera,
+els esdeveniments s'obtenen de `Agenda.xlsx` executant:
+
+```bash
+python3 update_events.py
+```

--- a/events.json
+++ b/events.json
@@ -1,0 +1,4 @@
+[
+  {"Data": "2023-08-02", "Hora": "19:00", "Títol": "Torneig d'estiu"},
+  {"Data": "2023-08-04", "Hora": "20:00", "Títol": "Partit amist\u00f3s"}
+]

--- a/main.js
+++ b/main.js
@@ -27,6 +27,8 @@ let classAnySeleccionat = null;
 let classModalitatSeleccionada = '3 BANDES';
 let classCategoriaSeleccionada = null;
 
+let events = [];
+
 function adjustChartSize() {
   const chartContainer = document.getElementById('player-chart');
   if (chartContainer) {
@@ -46,9 +48,10 @@ function adjustChartSize() {
 function inicialitza() {
   Promise.all([
     fetch('ranquing.json').then(r => r.json()),
-    fetch('classificacions.json').then(r => r.json()).catch(() => [])
+    fetch('classificacions.json').then(r => r.json()).catch(() => []),
+    fetch('events.json').then(r => r.json()).catch(() => [])
   ])
-    .then(([dadesRanking, dadesClass]) => {
+    .then(([dadesRanking, dadesClass, dadesEvents]) => {
       ranquing = dadesRanking;
       anys = [...new Set(dadesRanking.map(d => parseInt(d.Any, 10)))]
         .sort((a, b) => a - b);
@@ -60,6 +63,8 @@ function inicialitza() {
       classAnySeleccionat = classYears[classYears.length - 1] || null;
       const categories = new Set(dadesClass.map(d => d.Categoria));
       classCategoriaSeleccionada = categories.values().next().value || null;
+
+      events = dadesEvents;
 
       preparaSelectors();
       preparaSelectorsClassificacio();
@@ -230,6 +235,30 @@ function mostraClassificacio() {
   cont.appendChild(taula);
 }
 
+function mostraAgenda() {
+  const cont = document.getElementById('content');
+  cont.innerHTML = '';
+  const taula = document.createElement('table');
+  const cap = document.createElement('tr');
+  ['Data', 'Hora', 'Títol'].forEach(t => {
+    const th = document.createElement('th');
+    th.textContent = t;
+    cap.appendChild(th);
+  });
+  taula.appendChild(cap);
+
+  events.forEach(ev => {
+    const tr = document.createElement('tr');
+    ['Data', 'Hora', 'Títol'].forEach(clau => {
+      const td = document.createElement('td');
+      td.textContent = ev[clau];
+      tr.appendChild(td);
+    });
+    taula.appendChild(tr);
+  });
+  cont.appendChild(taula);
+}
+
 
 function mostraEvolucioJugador(jugador, nom) {
   const modalitats = ['3 BANDES', 'BANDA', 'LLIURE'];
@@ -330,6 +359,13 @@ document.getElementById('btn-classificacio').addEventListener('click', () => {
   document.getElementById('classificacio-filters').style.display = 'flex';
   document.getElementById('content').style.display = 'block';
   mostraClassificacio();
+});
+
+document.getElementById('btn-agenda').addEventListener('click', () => {
+  document.getElementById('filters-row').style.display = 'none';
+  document.getElementById('classificacio-filters').style.display = 'none';
+  document.getElementById('content').style.display = 'block';
+  mostraAgenda();
 });
 
 

--- a/server.py
+++ b/server.py
@@ -31,6 +31,17 @@ class Handler(http.server.SimpleHTTPRequestHandler):
                 self.send_response(500)
                 self.end_headers()
             return
+        if self.path == '/update-events':
+            try:
+                subprocess.run(['python3', 'update_events.py'], check=True)
+                self.send_response(200)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(b'{"status": "ok"}')
+            except subprocess.CalledProcessError:
+                self.send_response(500)
+                self.end_headers()
+            return
         return http.server.SimpleHTTPRequestHandler.do_GET(self)
 
 if __name__ == '__main__':

--- a/service-worker.js
+++ b/service-worker.js
@@ -10,6 +10,7 @@ self.addEventListener('install', event => {
         'https://cdn.jsdelivr.net/npm/chart.js',
         './ranquing.json',
         './classificacions.json',
+        './events.json',
         './icons/icon-192.png',
         './icons/icon-512.png'
       ])

--- a/update_events.py
+++ b/update_events.py
@@ -1,0 +1,52 @@
+import zipfile
+import xml.etree.ElementTree as ET
+import json
+from pathlib import Path
+
+XLSX_FILE = Path('Agenda.xlsx')
+JSON_FILE = Path('events.json')
+
+NS = {'a': 'http://schemas.openxmlformats.org/spreadsheetml/2006/main'}
+
+def load_shared_strings(z):
+    data = z.read('xl/sharedStrings.xml')
+    tree = ET.fromstring(data)
+    strings = []
+    for t in tree.findall('.//a:t', NS):
+        strings.append(t.text or '')
+    return strings
+
+def cell_value(cell, strings):
+    v = cell.find('a:v', NS)
+    if v is None:
+        return ''
+    val = v.text or ''
+    if cell.get('t') == 's':
+        idx = int(val)
+        return strings[idx]
+    return val
+
+def update():
+    with zipfile.ZipFile(XLSX_FILE) as z:
+        strings = load_shared_strings(z)
+        sheet_xml = z.read('xl/worksheets/sheet1.xml')
+    sheet = ET.fromstring(sheet_xml)
+    sheet_data = sheet.find('a:sheetData', NS)
+    rows = []
+    for row in sheet_data.findall('a:row', NS):
+        r_index = int(row.get('r'))
+        if r_index == 1:
+            continue  # header row
+        cells = {c.get('r')[0]: c for c in row.findall('a:c', NS)}
+        record = {
+            'Data': cell_value(cells.get('A', ET.Element('c')), strings),
+            'Hora': cell_value(cells.get('B', ET.Element('c')), strings),
+            'Títol': cell_value(cells.get('C', ET.Element('c')), strings),
+        }
+        # ignore completely empty rows
+        if any(record.values()):
+            rows.append(record)
+    JSON_FILE.write_text(json.dumps(rows, ensure_ascii=False, indent=2))
+
+if __name__ == '__main__':
+    update()


### PR DESCRIPTION
## Summary
- add `events.json` and script to build it from `Agenda.xlsx`
- cache events in the service worker
- extend server to update the new events file
- show the agenda in the web app
- document how to update events

## Testing
- `python3 -m py_compile server.py update_classificacions.py update_ranquing.py update_events.py`

------
https://chatgpt.com/codex/tasks/task_e_688ce10026d4832e860a3fbb1b59c395