### PR TITLE
Add workflow to update JSON files

### DIFF
--- a/.github/workflows/update-jsons.yml
+++ b/.github/workflows/update-jsons.yml
@@ -1,0 +1,37 @@
+name: Update JSON files
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+    - cron: '0 21 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run update scripts
+        run: |
+          python update_classificacions.py
+          python update_ranquing.py
+      - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add classificacions.json ranquing.json
+            git commit -m "Update JSON files"
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
## Summary
- add a scheduled workflow that runs the existing Python scripts
  to refresh JSON data

## Testing
- `python -m py_compile server.py update_classificacions.py update_ranquing.py`

------
https://chatgpt.com/codex/tasks/task_e_688ce23ab3d0832e81ce074d654b9ba0