### PR TITLE
Add workflow to update JSON files

### DIFF
--- a/.github/workflows/update-jsons.yml
+++ b/.github/workflows/update-jsons.yml
@@ -1,0 +1,38 @@
+name: Update JSON files
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+    - cron: '0 21 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run update scripts
+        run: |
+          python update_classificacions.py
+          python update_ranquing.py
+          python update_eventa.py
+      - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add classificacions.json ranquing.json events.json
+            git commit -m "Update JSON files"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/events.json
+++ b/events.json
@@ -1,0 +1,7 @@
+[
+  {"date": "2024-04-01", "title": "Torneig Primavera"},
+  {"date": "2024-04-05", "title": "Partida amistosa"},
+  {"date": "2024-04-12", "title": "Campionat local"},
+  {"date": "2024-04-16", "title": "Entrenament especial"},
+  {"date": "2024-04-22", "title": "Final de temporada"}
+]

--- a/update_eventa.py
+++ b/update_eventa.py
@@ -1,0 +1,37 @@
+import json
+from datetime import datetime
+from pathlib import Path
+import gspread
+
+SA_FILENAME = '/tmp/sa.json'
+SPREADSHEET_ID = '10HIcmcf5CAqB2OAiKEqb49djG9ysu-1koxvRmrwT-Fk'
+WORKSHEET_NAME = 'Agenda'
+OUTPUT_FILE = Path('events.json')
+
+def update():
+    gc = gspread.service_account(filename=SA_FILENAME)
+    sh = gc.open_by_key(SPREADSHEET_ID)
+    ws = sh.worksheet(WORKSHEET_NAME)
+    rows = ws.get_all_values()[1:]
+    events = []
+    for row in rows:
+        if not any(row):
+            continue
+        date_str = row[0].strip()
+        if not date_str:
+            continue
+        hour = row[1].strip() if len(row) > 1 else ''
+        title = row[2].strip() if len(row) > 2 else ''
+        date_iso = datetime.strptime(date_str, '%d/%m/%Y').date().isoformat()
+        event = {
+            'date': date_iso,
+            'title': title,
+            'allDay': not hour,
+        }
+        if hour:
+            event['time'] = hour
+        events.append(event)
+    OUTPUT_FILE.write_text(json.dumps(events, ensure_ascii=False, indent=2))
+
+if __name__ == '__main__':
+    update()


### PR DESCRIPTION
## Summary
- add eventa update script using Google Sheets
- update scheduled workflow to run all three update scripts
- rename JSON file for events to `events.json`

## Testing
- `python3 -m py_compile server.py update_classificacions.py update_ranquing.py update_eventa.py`


------
https://chatgpt.com/codex/tasks/task_e_688ce23ab3d0832e81ce074d654b9ba0