### PR TITLE
Open agenda on PWA load

### DIFF
--- a/main.js
+++ b/main.js
@@ -68,6 +68,7 @@ function inicialitza() {
 
       preparaSelectors();
       preparaSelectorsClassificacio();
+      document.getElementById('btn-agenda').click();
     })
     .catch(err => {
       console.error('Error carregant dades', err);


### PR DESCRIPTION
## Summary
- show the agenda by default once data loads

## Testing
- `python3 -m py_compile server.py update_classificacions.py update_events.py update_ranquing.py`

------
https://chatgpt.com/codex/tasks/task_e_688d099ed9d4832ea74a3af5933bf9d9