### PR TITLE
Implement monthly calendar agenda

### DIFF
--- a/style.css
+++ b/style.css
@@ -220,4 +220,41 @@ tr:nth-child(even) {
   text-decoration: underline;
 }
 
+#calendar-container {
+  margin-bottom: 1rem;
+}
+
+.calendar-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.calendar-table th,
+.calendar-table td {
+  width: 14.28%;
+  height: 2.5rem;
+  text-align: center;
+}
+
+.calendar-table td.event-inici {
+  background: #c8e6c9;
+  cursor: pointer;
+}
+
+.calendar-table td.event-fi {
+  background: #ffcdd2;
+  cursor: pointer;
+}
+
+.calendar-table td.event-other {
+  background: #bbdefb;
+  cursor: pointer;
+}
+
+.selected-event {
+  background: #fff9c4 !important;
+}
+
 


### PR DESCRIPTION
## Summary
- Replace upcoming-events table with navigable monthly calendar
- Highlight dates with "Inici" in green, "Fi" in red and other events in blue
- Sync calendar clicks with event list for selected month

## Testing
- `node --check main.js`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688e3adeda98832ebdcc4d25f5b6d99d