### PR TITLE
Fix calendar day highlighting offset

### DIFF
--- a/main.js
+++ b/main.js
@@ -301,7 +301,7 @@ function mostraAgenda() {
         if ((i === 0 && j < start) || date > daysInMonth) {
           cell.textContent = '';
         } else {
-          const iso = new Date(agendaAny, agendaMes, date).toISOString().split('T')[0];
+          const iso = new Date(Date.UTC(agendaAny, agendaMes, date)).toISOString().split('T')[0];
           cell.textContent = date;
           cell.dataset.date = iso;
           const dayEvents = events.filter(ev => ev['Data'] === iso);


### PR DESCRIPTION
## Summary
- ensure agenda calendar uses UTC dates so events display on the correct day

## Testing
- `node --check main.js`
- `python -m py_compile server.py update_eventa.py update_events.py update_ranquing.py update_classificacions.py`


------
https://chatgpt.com/codex/tasks/task_e_688e3e99fbd8832ebee35b27637a8caf