### PR TITLE
Afegeix secció Torneig en Curs amb menús dinàmics

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <button id="btn-agenda">Agenda</button>
     <button id="btn-ranking">Rànquings</button>
     <button id="btn-classificacio">Classificacions</button>
+    <button id="btn-torneig">Torneig en Curs</button>
     <div id="filters-row" style="display:none">
       <select id="year-select"></select>
       <div id="modalitat-buttons" class="button-group secondary-buttons">
@@ -31,6 +32,13 @@
         <button data-mod="LLIURE">Lliure</button>
       </div>
       <select id="categoria-select"></select>
+    </div>
+    <div id="torneig-buttons" class="button-group secondary-buttons" style="display:none">
+      <button data-file="modalitat.json">Modalitat</button>
+      <button data-file="inscrits.json">Inscrits</button>
+      <button data-file="calendari.json">Calendari</button>
+      <button data-file="partides.json">Partides</button>
+      <button data-file="classificacio.json">Classificació</button>
     </div>
     <!-- aquí es poden afegir més botons en el futur -->
     </div>

--- a/main.js
+++ b/main.js
@@ -448,9 +448,44 @@ function mostraEvolucioJugador(jugador, nom) {
 
 }
 
+function mostraTorneig(dades) {
+  const cont = document.getElementById('content');
+  cont.innerHTML = '';
+  if (!Array.isArray(dades) || dades.length === 0) {
+    cont.innerHTML = '<p>No hi ha dades.</p>';
+    return;
+  }
+  if (typeof dades[0] === 'object' && !Array.isArray(dades[0])) {
+    const headers = [...new Set(dades.flatMap(obj => Object.keys(obj)))];
+    const taula = document.createElement('table');
+    const cap = document.createElement('tr');
+    headers.forEach(h => {
+      const th = document.createElement('th');
+      th.textContent = h;
+      cap.appendChild(th);
+    });
+    taula.appendChild(cap);
+    dades.forEach(reg => {
+      const tr = document.createElement('tr');
+      headers.forEach(h => {
+        const td = document.createElement('td');
+        td.textContent = reg[h] || '';
+        tr.appendChild(td);
+      });
+      taula.appendChild(tr);
+    });
+    cont.appendChild(taula);
+  } else {
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(dades, null, 2);
+    cont.appendChild(pre);
+  }
+}
+
 document.getElementById('btn-ranking').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'flex';
   document.getElementById('classificacio-filters').style.display = 'none';
+  document.getElementById('torneig-buttons').style.display = 'none';
   document.getElementById('content').style.display = 'block';
   mostraRanquing();
 });
@@ -460,6 +495,7 @@ document.getElementById('btn-ranking').addEventListener('click', () => {
 document.getElementById('btn-classificacio').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'none';
   document.getElementById('classificacio-filters').style.display = 'flex';
+  document.getElementById('torneig-buttons').style.display = 'none';
   document.getElementById('content').style.display = 'block';
   mostraClassificacio();
 });
@@ -467,8 +503,30 @@ document.getElementById('btn-classificacio').addEventListener('click', () => {
 document.getElementById('btn-agenda').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'none';
   document.getElementById('classificacio-filters').style.display = 'none';
+  document.getElementById('torneig-buttons').style.display = 'none';
   document.getElementById('content').style.display = 'block';
   mostraAgenda();
+});
+
+document.getElementById('btn-torneig').addEventListener('click', () => {
+  document.getElementById('filters-row').style.display = 'none';
+  document.getElementById('classificacio-filters').style.display = 'none';
+  document.getElementById('torneig-buttons').style.display = 'flex';
+  document.getElementById('content').style.display = 'block';
+  document.getElementById('content').innerHTML = '';
+});
+
+document.querySelectorAll('#torneig-buttons button').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const file = btn.dataset.file;
+    fetch(`data/${file}`)
+      .then(r => r.json())
+      .then(d => mostraTorneig(d))
+      .catch(err => {
+        console.error('Error carregant dades del torneig', err);
+        document.getElementById('content').innerHTML = '<p>Error carregant dades.</p>';
+      });
+  });
 });
 
 

--- a/style.css
+++ b/style.css
@@ -123,6 +123,14 @@ button:active {
   width: 100%;
 }
 
+#torneig-buttons {
+  margin-top: 0.5rem;
+  display: none;
+  align-items: center;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
 #content {
   margin-top: 1rem;
   overflow-x: auto;


### PR DESCRIPTION
## Resum
- Afegeix el botó "Torneig en Curs" i un submenú amb accessos a Modalitat, Inscrits, Calendari, Partides i Classificació.
- Estilitza el nou submenú amb CSS i el manté ocult fins que se selecciona el botó principal.
- Implementa la càrrega i visualització de fitxers JSON en taules HTML i gestiona la visibilitat dels diferents menús.

## Proves
- `npm test` (falla: Could not read package.json)
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6891deffc398832e935ef8de5b1ed0d9