### PR TITLE
Display Social Modalitat title above tournament buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
       </div>
       <select id="categoria-select"></select>
     </div>
+    <h2 id="torneig-title" style="display:none"></h2>
     <div id="torneig-buttons" class="button-group secondary-buttons" style="display:none">
       <button data-file="inscrits.json">Inscrits</button>
       <button data-file="calendari.json">Calendari</button>

--- a/main.js
+++ b/main.js
@@ -452,11 +452,6 @@ function mostraEvolucioJugador(jugador, nom) {
 function mostraTorneig(dades) {
   const cont = document.getElementById('content');
   cont.innerHTML = '';
-  if (torneigModalitat) {
-    const h2 = document.createElement('h2');
-    h2.textContent = `Social Modalitat ${torneigModalitat}`;
-    cont.appendChild(h2);
-  }
   if (!dades) {
     return;
   }
@@ -550,6 +545,7 @@ document.getElementById('btn-ranking').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'flex';
   document.getElementById('classificacio-filters').style.display = 'none';
   document.getElementById('torneig-buttons').style.display = 'none';
+  document.getElementById('torneig-title').style.display = 'none';
   document.getElementById('content').style.display = 'block';
   mostraRanquing();
 });
@@ -560,6 +556,7 @@ document.getElementById('btn-classificacio').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'none';
   document.getElementById('classificacio-filters').style.display = 'flex';
   document.getElementById('torneig-buttons').style.display = 'none';
+  document.getElementById('torneig-title').style.display = 'none';
   document.getElementById('content').style.display = 'block';
   mostraClassificacio();
 });
@@ -568,6 +565,7 @@ document.getElementById('btn-agenda').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'none';
   document.getElementById('classificacio-filters').style.display = 'none';
   document.getElementById('torneig-buttons').style.display = 'none';
+  document.getElementById('torneig-title').style.display = 'none';
   document.getElementById('content').style.display = 'block';
   mostraAgenda();
 });
@@ -576,6 +574,7 @@ document.getElementById('btn-torneig').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'none';
   document.getElementById('classificacio-filters').style.display = 'none';
   document.getElementById('torneig-buttons').style.display = 'flex';
+  const title = document.getElementById('torneig-title');
   const cont = document.getElementById('content');
   cont.style.display = 'block';
   cont.innerHTML = '';
@@ -587,11 +586,13 @@ document.getElementById('btn-torneig').addEventListener('click', () => {
         ? d.map(m => m.Modalitat).join(', ')
 
         : (d.Modalitat || '');
-      mostraTorneig();
+      title.textContent = `Social Modalitat ${torneigModalitat}`;
+      title.style.display = 'block';
     })
     .catch(err => {
       console.error('Error carregant modalitat', err);
       cont.innerHTML = '<p>Error carregant modalitat.</p>';
+      title.style.display = 'none';
     });
 });
 


### PR DESCRIPTION
## Summary
- place a dedicated heading for "Social Modalitat" above the tournament buttons
- toggle the heading visibility across menu sections

## Testing
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689202eebcc4832ea441f81451520252