### PR TITLE
Add player filter to tournament matches

### DIFF
--- a/main.js
+++ b/main.js
@@ -459,6 +459,8 @@ function mostraPartides(partides) {
   }
 
   const categories = [...new Set(partides.map(p => p["🏆 Categoria de la partida"]))].sort();
+  const filters = document.createElement('div');
+  filters.id = 'partides-filters';
 
   const select = document.createElement('select');
   select.id = 'partides-categoria-select';
@@ -468,15 +470,28 @@ function mostraPartides(partides) {
     opt.textContent = `Categoria ${cat}`;
     select.appendChild(opt);
   });
-  cont.appendChild(select);
+  filters.appendChild(select);
+
+  const input = document.createElement('input');
+  input.id = 'partides-player-filter';
+  input.type = 'text';
+  input.placeholder = 'Nom del jugador';
+  filters.appendChild(input);
+
+  cont.appendChild(filters);
 
   const list = document.createElement('div');
   cont.appendChild(list);
 
-  function render(cat) {
+  function render(cat, filtre = '') {
     list.innerHTML = '';
     partides
       .filter(p => p["🏆 Categoria de la partida"] === cat)
+      .filter(p => {
+        const nom1 = (p["🎱 Nom del Jugador 1"] || '').toLowerCase();
+        const nom2 = (p["🎱 Nom del Jugador 2"] || '').toLowerCase();
+        return nom1.includes(filtre) || nom2.includes(filtre);
+      })
       .forEach(p => {
         const nom1 = (p["🎱 Nom del Jugador 1"] || '').trim();
         const nom2 = (p["🎱 Nom del Jugador 2"] || '').trim();
@@ -526,7 +541,12 @@ function mostraPartides(partides) {
       });
   }
 
-  select.addEventListener('change', () => render(select.value));
+  function update() {
+    render(select.value, input.value.trim().toLowerCase());
+  }
+
+  select.addEventListener('change', update);
+  input.addEventListener('input', update);
   if (categories.length) {
     render(categories[0]);
   }

--- a/style.css
+++ b/style.css
@@ -97,7 +97,8 @@ button:active {
 
 #classificacio-year-select,
 #categoria-select,
-#partides-categoria-select {
+#partides-categoria-select,
+#partides-player-filter {
   border: 1px solid #ccc;
   border-radius: 4px;
   padding: 0.5rem;
@@ -117,6 +118,14 @@ button:active {
 }
 
 #classificacio-filters {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+#partides-filters {
   margin-top: 0.5rem;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- allow filtering matches by player name in Partides view
- style new filter controls

## Testing
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68920e75a6a0832e94a479eb63d32603