### PR TITLE
Add divider line between partidas

### DIFF
--- a/style.css
+++ b/style.css
@@ -173,6 +173,11 @@ td {
   margin-bottom: 1rem;
   width: 100%;
   border-collapse: collapse;
+  border-bottom: 1px solid #ddd;
+}
+
+.partida:last-of-type {
+  border-bottom: none;
 }
 
 .partida col.jugadors {


### PR DESCRIPTION
## Summary
- Add bottom border to each partida table so games are separated by a line
- Remove border on the final partida table to avoid trailing separator

## Testing
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689210f4bb4c832e95674b3db61f3adf