### PR TITLE
Reset player filter when changing match category

### DIFF
--- a/main.js
+++ b/main.js
@@ -575,7 +575,10 @@ function mostraPartides(partides) {
     render(select.value, input.value.trim().toLowerCase());
   }
 
-  select.addEventListener('change', update);
+  select.addEventListener('change', () => {
+    input.value = '';
+    update();
+  });
   input.addEventListener('input', update);
   if (categories.length) {
     render(categories[0], input.value.trim().toLowerCase());


### PR DESCRIPTION
## Summary
- Reset the player filter when the match category changes so players aren't filtered by stale text

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689217f2b918832e9dbeec50e5650386