### PR TITLE
feat: update classification columns

### DIFF
--- a/main.js
+++ b/main.js
@@ -209,7 +209,7 @@ function mostraClassificacio() {
   cont.innerHTML = '';
   const taula = document.createElement('table');
   const cap = document.createElement('tr');
-  ['Posició', 'Jugador', 'Punts', 'Caramboles', 'Entrades', 'Mitjana General', 'Mitjana Particular'].forEach(t => {
+  ['#', 'Jugador', 'PJ', 'P', 'C', 'E', 'MG', 'MM'].forEach(t => {
     const th = document.createElement('th');
     th.textContent = t;
     cap.appendChild(th);
@@ -217,20 +217,31 @@ function mostraClassificacio() {
   taula.appendChild(cap);
 
   const dades = classificacions
-    .filter(r =>
-      parseInt(r.Any, 10) === classAnySeleccionat &&
-      r.Modalitat === classModalitatSeleccionada &&
-      r.Categoria === classCategoriaSeleccionada
+    .filter(
+      r =>
+        parseInt(r.Any, 10) === classAnySeleccionat &&
+        r.Modalitat === classModalitatSeleccionada &&
+        r.Categoria === classCategoriaSeleccionada
     )
     .sort((a, b) => parseInt(a.Posició, 10) - parseInt(b.Posició, 10));
 
   dades.forEach(reg => {
     const tr = document.createElement('tr');
-    ['Posició', 'Jugador', 'Punts', 'Caramboles', 'Entrades', 'MitjanaGeneral', 'MitjanaParticular'].forEach(clau => {
+    const camps = [
+      reg['Posició'],
+      reg['Jugador'] || reg['Nom'] || '',
+      reg['PartidesJugades'] || reg['Partides jugades'] || reg['PJ'] || '',
+      reg['Punts'],
+      reg['Caramboles'],
+      reg['Entrades'],
+      reg['MitjanaGeneral'] || reg['Mitjana'] || '',
+      reg['MitjanaParticular'] || reg['Millor mitjana'] || ''
+    ];
+    camps.forEach((valor, idx) => {
       const td = document.createElement('td');
-      let valor = reg[clau];
-      if (clau === 'MitjanaGeneral' || clau === 'MitjanaParticular') {
-        valor = Number.parseFloat(valor).toFixed(3);
+      if (idx >= 6 && valor !== '') {
+        const num = Number.parseFloat(valor);
+        valor = Number.isNaN(num) ? valor : num.toFixed(3);
       }
       td.textContent = valor;
       tr.appendChild(td);


### PR DESCRIPTION
## Summary
- show classification table columns in order `#`, `Jugador`, `PJ`, `P`, `C`, `E`, `MG`, `MM`
- support both legacy and new field names for classification data

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68921a513abc832e84526c46801fe2d8