### PR TITLE
Afegir botons de categoria a classificacions

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         <button data-mod="BANDA">Banda</button>
         <button data-mod="LLIURE">Lliure</button>
       </div>
-      <select id="categoria-select"></select>
+      <div id="categoria-buttons" class="button-group secondary-buttons"></div>
     </div>
     <h2 id="torneig-title" style="display:none"></h2>
     <div id="torneig-buttons" class="button-group secondary-buttons" style="display:none">

--- a/main.js
+++ b/main.js
@@ -136,19 +136,20 @@ function preparaSelectorsClassificacio() {
     });
   });
 
-  const catSel = document.getElementById('categoria-select');
-  catSel.innerHTML = '';
+  const catBtns = document.getElementById('categoria-buttons');
+  catBtns.innerHTML = '';
   const cats = [...new Set(classificacions.map(c => c.Categoria))].sort();
   cats.forEach(cat => {
-    const opt = document.createElement('option');
-    opt.value = cat;
-    opt.textContent = cat;
-    if (cat === classCategoriaSeleccionada) opt.selected = true;
-    catSel.appendChild(opt);
-  });
-  catSel.addEventListener('change', () => {
-    classCategoriaSeleccionada = catSel.value;
-    mostraClassificacio();
+    const btn = document.createElement('button');
+    btn.textContent = cat;
+    if (cat === classCategoriaSeleccionada) btn.classList.add('selected');
+    btn.addEventListener('click', () => {
+      classCategoriaSeleccionada = cat;
+      catBtns.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
+      btn.classList.add('selected');
+      mostraClassificacio();
+    });
+    catBtns.appendChild(btn);
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -96,7 +96,6 @@ button:active {
 }
 
 #classificacio-year-select,
-#categoria-select,
 #partides-categoria-select,
 #partides-player-filter {
   border: 1px solid #ccc;


### PR DESCRIPTION
## Resum
- Substituït el selector de categoria per una fila de botons dinamics.
- Les classificacions es filtren en clicar el botó de categoria corresponent.
- Eliminat l'estil antic del selector de categoria.

## Proves
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68921be2e848832eaab14e72d93d7d3a