### PR TITLE
Refine main menu buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
     <h1><img src="icons/icon-192.png" alt="Logo" class="header-logo">Secció de Billar del Foment Martinenc</h1>
     <div id="menu">
     <button id="btn-agenda">Agenda</button>
-    <button id="btn-ranking">Rànquings</button>
-    <button id="btn-classificacio">Classificacions</button>
-    <button id="btn-torneig">Torneig en Curs</button>
+    <button id="btn-torneig">Social en curs</button>
+    <button id="btn-ranking">Rànquings Històric</button>
+    <button id="btn-classificacio">Clas. Històric</button>
     <div id="filters-row" style="display:none">
       <select id="year-select"></select>
       <div id="modalitat-buttons" class="button-group secondary-buttons">

--- a/style.css
+++ b/style.css
@@ -46,6 +46,10 @@ h1 {
   margin-bottom: 0.5rem;
 }
 
+#menu > button {
+  flex: 1 1 calc(25% - 0.5rem);
+}
+
 button {
   border: none;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- rename menu buttons: "Social en curs" next to Agenda
- update labels to "Rànquings Històric" and "Clas. Històric"
- ensure equal width for primary buttons via flex styling

## Testing
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689223727680832e8ef9771a3a3faffc