### PR TITLE
Actualitza botons del menú principal

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
     <h1><img src="icons/icon-192.png" alt="Logo" class="header-logo">Secció de Billar del Foment Martinenc</h1>
     <div id="menu">
     <button id="btn-agenda">Agenda</button>
-    <button id="btn-ranking">Rànquings</button>
-    <button id="btn-classificacio">Classificacions</button>
-    <button id="btn-torneig">Torneig en Curs</button>
+    <button id="btn-torneig">Social en curs</button>
+    <button id="btn-ranking">Rànquings Històric</button>
+    <button id="btn-classificacio">Clas. Històric</button>
     <div id="filters-row" style="display:none">
       <select id="year-select"></select>
       <div id="modalitat-buttons" class="button-group secondary-buttons">

--- a/style.css
+++ b/style.css
@@ -46,6 +46,10 @@ h1 {
   margin-bottom: 0.5rem;
 }
 
+#menu > button {
+  flex: 1;
+}
+
 button {
   border: none;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- Reordena els botons principals per col·locar **Social en curs** al costat d'**Agenda** i renombra els altres a **Rànquings Històric** i **Clas. Històric**.
- Afegeix estil flex per uniformitzar l'amplada dels quatre botons principals.

## Testing
- `node --check main.js && echo "main.js OK"`
- `python -m py_compile server.py && echo "server.py OK"`


------
https://chatgpt.com/codex/tasks/task_e_6892258f594c832ea79c6a0f5d08aa80