### PR TITLE
Add category filters to tournament sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
       <button data-file="partides.json">Resultats</button>
       <button data-file="classificacio.json">Classificació</button>
     </div>
+    <div id="torneig-category-buttons" class="button-group secondary-buttons" style="display:none"></div>
     <!-- aquí es poden afegir més botons en el futur -->
     </div>
     <div id="content"></div>


### PR DESCRIPTION
## Summary
- Add dedicated category filter buttons for tournament pages
- Support category filtering across inscriptions, classifications, and match results
- Streamline tournament navigation and hide filters when not needed

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68922facef9c832ebec45d22538f32a9