### PR TITLE
Make grouped buttons responsive with equal width

### DIFF
--- a/style.css
+++ b/style.css
@@ -72,8 +72,16 @@ button:active {
   transform: scale(0.98);
 }
 
+
+/* Ensure grouped buttons are responsive and share equal width */
 .button-group {
-  display: inline-block;
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.button-group button {
+  flex: 1;
 }
 
 .button-group button.selected {


### PR DESCRIPTION
## Summary
- Use flexbox for button groups so same-color buttons expand responsively and share equal width.

## Testing
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6892387bc650832eab74410b5c8756f8