### PR TITLE
Ensure tournament matches are separated by visible lines

### DIFF
--- a/style.css
+++ b/style.css
@@ -211,7 +211,8 @@ td {
   border-bottom: 1px solid #ddd;
 }
 
-.partida:last-of-type {
+/* Remove bottom border only for the last match container */
+.table-responsive:last-of-type .partida {
   border-bottom: none;
 }
 


### PR DESCRIPTION
## Summary
- keep a bottom border between tournament games so each match is separated

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689255612d24832ea12fcf3c6d03ab22