### PR TITLE
Version service worker on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ els esdeveniments s'obtenen de `agenda.xlsx` executant:
 ```bash
 python3 update_events.py
 ```
+
+### Actualitzar la versió del service worker
+
+Abans de fer un build o desplegar, cal actualitzar la versió del
+service worker per garantir que els canvis es propaguin als clients.
+
+```bash
+python3 tools/update_sw_version.py
+```

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,8 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.3/workbox-sw.js');
 
+// This value is replaced at build time by tools/update_sw_version.py
+const CACHE_VERSION = '20250805191510';
+
 // Activate new service worker as soon as it's finished installing
 workbox.core.skipWaiting();
 workbox.core.clientsClaim();
@@ -20,14 +23,14 @@ self.addEventListener('activate', (event) => {
 });
 
 workbox.precaching.precacheAndRoute([
-  { url: './style.css', revision: null },
-  { url: './main.js', revision: null },
+  { url: './style.css', revision: CACHE_VERSION },
+  { url: './main.js', revision: CACHE_VERSION },
   { url: 'https://cdn.jsdelivr.net/npm/chart.js', revision: null },
-  { url: './ranquing.json', revision: null },
-  { url: './classificacions.json', revision: null },
-  { url: './events.json', revision: null },
-  { url: './icons/icon-192.png', revision: null },
-  { url: './icons/icon-512.png', revision: null }
+  { url: './ranquing.json', revision: CACHE_VERSION },
+  { url: './classificacions.json', revision: CACHE_VERSION },
+  { url: './events.json', revision: CACHE_VERSION },
+  { url: './icons/icon-192.png', revision: CACHE_VERSION },
+  { url: './icons/icon-512.png', revision: CACHE_VERSION }
 ]);
 
 // index.html and navigation requests: Network First

--- a/tools/update_sw_version.py
+++ b/tools/update_sw_version.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from datetime import datetime, timezone
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SW_PATH = ROOT / 'service-worker.js'
+
+
+def main():
+    ts = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+    content = SW_PATH.read_text()
+    new_content, count = re.subn(r"const CACHE_VERSION = '.*';",
+                                 f"const CACHE_VERSION = '{ts}';",
+                                 content)
+    if count == 0:
+        raise SystemExit('CACHE_VERSION not found in service-worker.js')
+    SW_PATH.write_text(new_content)
+    print(f'Updated service worker version to {ts}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- version service worker and cache entries using a build timestamp
- document service worker version update steps
- add script to update service worker version automatically

## Testing
- `python3 tools/update_sw_version.py`
- `python3 server.py` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689257894484832e962409d9cd94d321