### PR TITLE
docs: add Horari and Enllaços sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ service worker per garantir que els canvis es propaguin als clients.
 ```bash
 python3 tools/update_sw_version.py
 ```
+
+## Horari
+
+Pròximament disponibles els horaris de les activitats.
+
+## Enllaços
+
+- [Foment Martinenc](https://www.fomentmartinenc.org/)


### PR DESCRIPTION
## Summary
- document schedule and external resources in README

## Testing
- `python -m py_compile server.py tools/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68925a504e78832e92c3fd2f09ab8e4e