### PR TITLE
Add navigation buttons for Horari and Enllaços

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
     <button id="btn-torneig">Social en curs</button>
     <button id="btn-ranking">Rànquings Històric</button>
     <button id="btn-classificacio">Clas. Històric</button>
+    <button id="btn-horari">Horari</button>
+    <button id="btn-enllacos">Enllaços</button>
     <div id="filters-row" style="display:none">
       <select id="year-select"></select>
       <div id="modalitat-buttons" class="button-group secondary-buttons">

--- a/main.js
+++ b/main.js
@@ -412,6 +412,28 @@ function mostraAgenda() {
   render();
 }
 
+function mostraHorari() {
+  const cont = document.getElementById('content');
+  cont.innerHTML = '';
+  const p = document.createElement('p');
+  p.textContent = 'Pròximament disponibles els horaris de les activitats.';
+  cont.appendChild(p);
+}
+
+function mostraEnllacos() {
+  const cont = document.getElementById('content');
+  cont.innerHTML = '';
+  const ul = document.createElement('ul');
+  const li = document.createElement('li');
+  const a = document.createElement('a');
+  a.href = 'https://www.fomentmartinenc.org/';
+  a.textContent = 'Foment Martinenc';
+  a.target = '_blank';
+  li.appendChild(a);
+  ul.appendChild(li);
+  cont.appendChild(ul);
+}
+
 
 function mostraEvolucioJugador(jugador, nom) {
   const modalitats = ['3 BANDES', 'BANDA', 'LLIURE'];
@@ -884,6 +906,26 @@ document.getElementById('btn-agenda').addEventListener('click', () => {
   document.getElementById('torneig-category-buttons').style.display = 'none';
   document.getElementById('content').style.display = 'block';
   mostraAgenda();
+});
+
+document.getElementById('btn-horari').addEventListener('click', () => {
+  document.getElementById('filters-row').style.display = 'none';
+  document.getElementById('classificacio-filters').style.display = 'none';
+  document.getElementById('torneig-buttons').style.display = 'none';
+  document.getElementById('torneig-title').style.display = 'none';
+  document.getElementById('torneig-category-buttons').style.display = 'none';
+  document.getElementById('content').style.display = 'block';
+  mostraHorari();
+});
+
+document.getElementById('btn-enllacos').addEventListener('click', () => {
+  document.getElementById('filters-row').style.display = 'none';
+  document.getElementById('classificacio-filters').style.display = 'none';
+  document.getElementById('torneig-buttons').style.display = 'none';
+  document.getElementById('torneig-title').style.display = 'none';
+  document.getElementById('torneig-category-buttons').style.display = 'none';
+  document.getElementById('content').style.display = 'block';
+  mostraEnllacos();
 });
 
 document.getElementById('btn-torneig').addEventListener('click', () => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.3/workbox-sw.js');
 
 // This value is replaced at build time by tools/update_sw_version.py
-const CACHE_VERSION = '20250805191510';
+const CACHE_VERSION = '20250805195705';
 
 // Activate new service worker as soon as it's finished installing
 workbox.core.skipWaiting();


### PR DESCRIPTION
## Summary
- Add Horari and Enllaços buttons to the main menu alongside Agenda and other sections
- Implement placeholder renderers and event handlers for the new sections
- Bump service worker cache version for updated assets

## Testing
- `python3 tools/update_sw_version.py`
- `python3 -m py_compile server.py tools/update_sw_version.py`


------
https://chatgpt.com/codex/tasks/task_e_68926178c1dc832e99129869a7e867f2