### PR TITLE
Add billiards section schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,17 @@ python3 tools/update_sw_version.py
 
 ## Horari
 
-Pròximament disponibles els horaris de les activitats.
+- Dilluns: 9:00 a 21:30
+- Dimarts: 10:30 a 21:30
+- Dimecres: 9:00 a 21:30
+- Dijous: 9:00 a 21:30
+- Divendres: 10:30 a 21:30
+- Dissabte: 9:00 a 21:30
+- Diumenge: 9:00 a 21:30
+
+Agost tancat
+
+Aquests horaris poden patir alteracions en funció dels horaris d'obertura del bar del Foment.
 
 ## Enllaços
 

--- a/main.js
+++ b/main.js
@@ -415,9 +415,36 @@ function mostraAgenda() {
 function mostraHorari() {
   const cont = document.getElementById('content');
   cont.innerHTML = '';
-  const p = document.createElement('p');
-  p.textContent = 'Pròximament disponibles els horaris de les activitats.';
-  cont.appendChild(p);
+  const table = document.createElement('table');
+  const hores = [
+    ['Dilluns', '9:00 a 21:30'],
+    ['Dimarts', '10:30 a 21:30'],
+    ['Dimecres', '9:00 a 21:30'],
+    ['Dijous', '9:00 a 21:30'],
+    ['Divendres', '10:30 a 21:30'],
+    ['Dissabte', '9:00 a 21:30'],
+    ['Diumenge', '9:00 a 21:30']
+  ];
+  hores.forEach(([dia, hora]) => {
+    const tr = document.createElement('tr');
+    const tdDia = document.createElement('td');
+    tdDia.textContent = dia;
+    const tdHora = document.createElement('td');
+    tdHora.textContent = hora;
+    tr.appendChild(tdDia);
+    tr.appendChild(tdHora);
+    table.appendChild(tr);
+  });
+  cont.appendChild(table);
+
+  const pAgost = document.createElement('p');
+  pAgost.textContent = 'Agost tancat';
+  cont.appendChild(pAgost);
+
+  const pNotes = document.createElement('p');
+  pNotes.textContent =
+    "Aquests horaris poden patir alteracions en funció dels horaris d'obertura del bar del Foment.";
+  cont.appendChild(pNotes);
 }
 
 function mostraEnllacos() {


### PR DESCRIPTION
## Summary
- Display detailed weekly opening hours in the Horari section, including August closure and notice about potential changes.
- Document the new schedule in the README.

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68927743ce64832e9746366498d77e52