### PR TITLE
Highlight link hierarchy with palette colors

### DIFF
--- a/main.js
+++ b/main.js
@@ -463,6 +463,7 @@ function mostraEnllacos() {
         const tipusDetails = document.createElement('details');
         const tipusSummary = document.createElement('summary');
         tipusSummary.textContent = tipus;
+        tipusSummary.classList.add('enllac-tipus');
         tipusDetails.appendChild(tipusSummary);
 
         const clubMap = {};
@@ -477,9 +478,11 @@ function mostraEnllacos() {
             const clubDetails = document.createElement('details');
             const clubSummary = document.createElement('summary');
             clubSummary.textContent = club;
+            clubSummary.classList.add('enllac-club');
             clubDetails.appendChild(clubSummary);
 
             const ul = document.createElement('ul');
+            ul.classList.add('enllacos-list');
             clubItems.forEach(ci => {
               const url =
                 ci.Enllaç ||
@@ -489,6 +492,7 @@ function mostraEnllacos() {
                 ci.Link;
               if (!url) return;
               const li = document.createElement('li');
+              li.classList.add('enllac-url');
               const a = document.createElement('a');
               a.href = url;
               a.target = '_blank';
@@ -500,6 +504,7 @@ function mostraEnllacos() {
             tipusDetails.appendChild(clubDetails);
           } else {
             const ul = document.createElement('ul');
+            ul.classList.add('enllacos-list');
             clubItems.forEach(ci => {
               const url =
                 ci.Enllaç ||
@@ -509,6 +514,7 @@ function mostraEnllacos() {
                 ci.Link;
               if (!url) return;
               const li = document.createElement('li');
+              li.classList.add('enllac-url');
               const a = document.createElement('a');
               a.href = url;
               a.target = '_blank';

--- a/style.css
+++ b/style.css
@@ -358,4 +358,43 @@ tr:nth-child(even) {
   background: #fff9c4 !important;
 }
 
+details summary {
+  cursor: pointer;
+}
+
+.enllac-tipus {
+  background: var(--primary);
+  color: #fff;
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  margin-top: 0.5rem;
+}
+
+.enllac-club {
+  background: var(--secondary);
+  color: #fff;
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  margin-left: 1rem;
+  margin-top: 0.3rem;
+}
+
+.enllacos-list {
+  list-style: none;
+  padding-left: 0;
+  margin-left: 2rem;
+}
+
+.enllac-url {
+  background: var(--category);
+  border-radius: 4px;
+  margin: 0.2rem 0;
+}
+
+.enllac-url a {
+  display: block;
+  padding: 0.2rem 0.4rem;
+  color: #fff;
+}
+
 


### PR DESCRIPTION
## Summary
- Color-code link groups so tipus, club and URL levels are visually distinct
- Style summaries and list items using PWA palette variables

## Testing
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68927caa2568832ead746a7d6b1ae6f1