### PR TITLE
Link single-club entries from club name

### DIFF
--- a/main.js
+++ b/main.js
@@ -475,15 +475,8 @@ function mostraEnllacos() {
 
         Object.entries(clubMap).forEach(([club, clubItems]) => {
           if (club) {
-            const clubDetails = document.createElement('details');
-            const clubSummary = document.createElement('summary');
-            clubSummary.textContent = club;
-            clubSummary.classList.add('enllac-club');
-            clubDetails.appendChild(clubSummary);
-
-            const ul = document.createElement('ul');
-            ul.classList.add('enllacos-list');
-            clubItems.forEach(ci => {
+            if (clubItems.length === 1) {
+              const ci = clubItems[0];
               const url =
                 ci.Enllaç ||
                 ci.Enllac ||
@@ -491,17 +484,43 @@ function mostraEnllacos() {
                 ci.Url ||
                 ci.Link;
               if (!url) return;
-              const li = document.createElement('li');
-              li.classList.add('enllac-url');
+              const p = document.createElement('p');
+              p.classList.add('enllac-club');
               const a = document.createElement('a');
               a.href = url;
               a.target = '_blank';
-              a.textContent = ci.Billar ? `Billar ${ci.Billar}` : club;
-              li.appendChild(a);
-              ul.appendChild(li);
-            });
-            clubDetails.appendChild(ul);
-            tipusDetails.appendChild(clubDetails);
+              a.textContent = club;
+              p.appendChild(a);
+              tipusDetails.appendChild(p);
+            } else {
+              const clubDetails = document.createElement('details');
+              const clubSummary = document.createElement('summary');
+              clubSummary.textContent = club;
+              clubSummary.classList.add('enllac-club');
+              clubDetails.appendChild(clubSummary);
+
+              const ul = document.createElement('ul');
+              ul.classList.add('enllacos-list');
+              clubItems.forEach(ci => {
+                const url =
+                  ci.Enllaç ||
+                  ci.Enllac ||
+                  ci.URL ||
+                  ci.Url ||
+                  ci.Link;
+                if (!url) return;
+                const li = document.createElement('li');
+                li.classList.add('enllac-url');
+                const a = document.createElement('a');
+                a.href = url;
+                a.target = '_blank';
+                a.textContent = ci.Billar ? `Billar ${ci.Billar}` : club;
+                li.appendChild(a);
+                ul.appendChild(li);
+              });
+              clubDetails.appendChild(ul);
+              tipusDetails.appendChild(clubDetails);
+            }
           } else {
             const ul = document.createElement('ul');
             ul.classList.add('enllacos-list');

--- a/style.css
+++ b/style.css
@@ -379,6 +379,11 @@ details summary {
   margin-top: 0.3rem;
 }
 
+.enllac-club > a {
+  color: #fff;
+  display: block;
+}
+
 .enllacos-list {
   list-style: none;
   padding-left: 0;


### PR DESCRIPTION
## Summary
- Link club names directly when they have a single URL, removing redundant link list entries
- Style club-name links to match existing design

## Testing
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68927f6bee1c832e9034624e6308d373