### PR TITLE
chore: update service worker version

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.3/workbox-sw.js');
 
 // This value is replaced at build time by tools/update_sw_version.py
-const CACHE_VERSION = '20250805195705';
+const CACHE_VERSION = '20250805222138';
 
 // Activate new service worker as soon as it's finished installing
 workbox.core.skipWaiting();


### PR DESCRIPTION
## Summary
- update cache version in service worker so clients get the latest PWA

## Testing
- `python3 tools/update_sw_version.py`
- `node --check service-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68928368a6cc832e86c0491d74f5b4a8