### PR TITLE
Rename navigation buttons to clarify purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ Agost tancat
 
 Aquests horaris poden patir alteracions en funció dels horaris d'obertura del bar del Foment.
 
-## Enllaços
+## Enllaços d'interès
 
 - [Foment Martinenc](https://www.fomentmartinenc.org/)

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
     <button id="btn-agenda">Agenda</button>
     <button id="btn-torneig">Social en curs</button>
     <button id="btn-ranking">Rànquings Històric</button>
-    <button id="btn-classificacio">Clas. Històric</button>
+    <button id="btn-classificacio">Històric Classificacions</button>
     <button id="btn-horari">Horari</button>
-    <button id="btn-enllacos">Enllaços</button>
+    <button id="btn-enllacos">Enllaços d'interès</button>
     <div id="filters-row" style="display:none">
       <select id="year-select"></select>
       <div id="modalitat-buttons" class="button-group secondary-buttons">


### PR DESCRIPTION
## Summary
- Rename `Enllaços` button to `Enllaços d'interès`
- Rename `Clas. Històric` button to `Històric Classificacions`
- Update README heading accordingly

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68928946ffc0832ebc6472fe08893f72