### PR TITLE
Show only player names in inscritos view

### DIFF
--- a/main.js
+++ b/main.js
@@ -791,11 +791,18 @@ function mostraTorneig(dades, file) {
   }
 
   // Format específic per als inscrits: array d'objectes amb categoria i nom
-  if (Array.isArray(dades) && dades[0] && 'Categoria jugador' in dades[0] && 'Nom jugador' in dades[0]) {
+  if (
+    Array.isArray(dades) &&
+    dades[0] &&
+    (('Categoria jugador' in dades[0] && 'Nom jugador' in dades[0]) ||
+      ('Categoria' in dades[0] && 'Nom' in dades[0]))
+  ) {
+    const catField = 'Categoria jugador' in dades[0] ? 'Categoria jugador' : 'Categoria';
+    const nomField = 'Nom jugador' in dades[0] ? 'Nom jugador' : 'Nom';
     const agrupats = dades.reduce((acc, reg) => {
-      const cat = reg['Categoria jugador'];
+      const cat = reg[catField];
       if (!acc[cat]) acc[cat] = [];
-      acc[cat].push((reg['Nom jugador'] || '').trim());
+      acc[cat].push((reg[nomField] || '').trim());
       return acc;
     }, {});
     const categories = Object.keys(agrupats);


### PR DESCRIPTION
## Summary
- Adjust inscrits renderer to group by category using `Nom` and show only player names

## Testing
- `node --check main.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68932162e1e0832ebb9c4d63710c07c0