### PR TITLE
Millores al calendari de partides

### DIFF
--- a/main.js
+++ b/main.js
@@ -776,10 +776,34 @@ function mostraCalendari(partides) {
   }
 
   partides.sort((a, b) => {
-    const dateA = new Date(`${a.Data}T${a.Hora}`);
-    const dateB = new Date(`${b.Data}T${b.Hora}`);
-    return dateA - dateB;
+    const dataDiff = (a.Data || '').localeCompare(b.Data || '');
+    if (dataDiff !== 0) return dataDiff;
+    const horaDiff = (a.Hora || '').localeCompare(b.Hora || '');
+    if (horaDiff !== 0) return horaDiff;
+    const billarA = parseInt((a.Billar || '').match(/\d+/), 10) || 0;
+    const billarB = parseInt((b.Billar || '').match(/\d+/), 10) || 0;
+    return billarA - billarB;
   });
+
+  const mesos = {
+    '01': 'gen',
+    '02': 'feb',
+    '03': 'mar',
+    '04': 'abr',
+    '05': 'mai',
+    '06': 'jun',
+    '07': 'jul',
+    '08': 'ago',
+    '09': 'set',
+    '10': 'oct',
+    '11': 'nov',
+    '12': 'des'
+  };
+
+  const dayCounts = partides.reduce((acc, p) => {
+    acc[p.Data] = (acc[p.Data] || 0) + 1;
+    return acc;
+  }, {});
 
   const taula = document.createElement('table');
   const cap = document.createElement('tr');
@@ -790,12 +814,25 @@ function mostraCalendari(partides) {
   });
   taula.appendChild(cap);
 
+  let lastData = null;
   partides.forEach(p => {
     const tr = document.createElement('tr');
-    const [yyyy, mm, dd] = (p.Data || '').split('-');
-    const dia = dd && mm && yyyy ? `${dd}/${mm}/${yyyy}` : '';
+    if (p.Data !== lastData) {
+      const tdDia = document.createElement('td');
+      const [yyyy, mm, dd] = (p.Data || '').split('-');
+      const diaNum = parseInt(dd, 10);
+      const diaTxt = mm && diaNum ? `${diaNum} de ${mesos[mm] || mm}` : '';
+      tdDia.textContent = diaTxt;
+      const count = dayCounts[p.Data];
+      if (count > 1) {
+        tdDia.rowSpan = count;
+        tdDia.classList.add('vertical-text');
+      }
+      tr.appendChild(tdDia);
+      lastData = p.Data;
+    }
     const billar = (p.Billar || '').replace('Billar ', 'B');
-    [dia, p.Hora || '', billar, (p['Jugador A'] || '').trim(), (p['Jugador B'] || '').trim()].forEach(val => {
+    [p.Hora || '', billar, (p['Jugador A'] || '').trim(), (p['Jugador B'] || '').trim()].forEach(val => {
       const td = document.createElement('td');
       td.textContent = val;
       tr.appendChild(td);

--- a/style.css
+++ b/style.css
@@ -250,6 +250,11 @@ td {
   vertical-align: middle;
 }
 
+.vertical-text {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+}
+
 .agenda-table td:nth-child(3) {
   text-align: left;
 }


### PR DESCRIPTION
## Resum
- Ordena el calendari per dia, hora i billar
- Agrupa els dies consecutius i mostra'ls en format vertical
- Mostra les dates com "dd de mes" en lloc de "dd/mm/aaaa"

## Proves
- `node --check main.js`
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689328bee6dc832e97efd775bc28df2c