### PR TITLE
Simplify calendar time display and emphasize day separation

### DIFF
--- a/main.js
+++ b/main.js
@@ -830,6 +830,7 @@ function mostraCalendari(partides) {
     }, {});
 
     const taula = document.createElement('table');
+    taula.classList.add('calendari-table');
     const cap = document.createElement('tr');
     ['Dia', 'Hora', 'Billar', 'J1', 'J2'].forEach(t => {
       const th = document.createElement('th');
@@ -842,6 +843,7 @@ function mostraCalendari(partides) {
     progFiltrades.forEach(p => {
       const tr = document.createElement('tr');
       if (p.Data !== lastData) {
+        tr.classList.add('new-day');
         const tdDia = document.createElement('td');
         const [yyyy, mm, dd] = (p.Data || '').split('-');
         const diaNum = parseInt(dd, 10);
@@ -858,7 +860,8 @@ function mostraCalendari(partides) {
         lastData = p.Data;
       }
       const billar = (p.Billar || '').replace('Billar ', 'B');
-      [p.Hora || '', billar, (p['Jugador A'] || '').trim(), (p['Jugador B'] || '').trim()].forEach(val => {
+      const hora = (p.Hora || '').replace(/:00$/, '');
+      [hora, billar, (p['Jugador A'] || '').trim(), (p['Jugador B'] || '').trim()].forEach(val => {
         const td = document.createElement('td');
         td.textContent = val;
         tr.appendChild(td);

--- a/style.css
+++ b/style.css
@@ -202,6 +202,10 @@ td {
   white-space: nowrap;
 }
 
+.calendari-table tr.new-day td {
+  border-top: 2px solid var(--text-color);
+}
+
 .partida {
   background: transparent;
   box-shadow: none;


### PR DESCRIPTION
## Summary
- Drop trailing `:00` from scheduled game times for a cleaner calendar view
- Add `calendari-table` styling to highlight day boundaries in the schedule

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689333e71880832eb05c5f92dfb12fe7