### PR TITLE
feat: add player filter to calendar

### DIFF
--- a/main.js
+++ b/main.js
@@ -787,6 +787,18 @@ function mostraCalendari(partides) {
     return billarA - billarB;
   });
 
+  const filters = document.createElement('div');
+  filters.id = 'calendari-filters';
+  const input = document.createElement('input');
+  input.id = 'calendari-player-filter';
+  input.type = 'text';
+  input.placeholder = 'Filtre Nom Jugador';
+  filters.appendChild(input);
+  cont.appendChild(filters);
+
+  const dataContainer = document.createElement('div');
+  cont.appendChild(dataContainer);
+
   const mesos = {
     '01': 'gen',
     '02': 'feb',
@@ -802,71 +814,87 @@ function mostraCalendari(partides) {
     '12': 'des'
   };
 
-  const dayCounts = programades.reduce((acc, p) => {
-    acc[p.Data] = (acc[p.Data] || 0) + 1;
-    return acc;
-  }, {});
+  function render(filtre = '') {
+    dataContainer.innerHTML = '';
 
-  const taula = document.createElement('table');
-  const cap = document.createElement('tr');
-  ['Dia', 'Hora', 'Billar', 'J1', 'J2'].forEach(t => {
-    const th = document.createElement('th');
-    th.textContent = t;
-    cap.appendChild(th);
-  });
-  taula.appendChild(cap);
-
-  let lastData = null;
-  programades.forEach(p => {
-    const tr = document.createElement('tr');
-    if (p.Data !== lastData) {
-      const tdDia = document.createElement('td');
-      const [yyyy, mm, dd] = (p.Data || '').split('-');
-      const diaNum = parseInt(dd, 10);
-
-      const diaTxt =
-        mm && diaNum ? `${diaNum}<br>${mesos[mm] || mm}` : '';
-      tdDia.innerHTML = diaTxt;
-
-      const count = dayCounts[p.Data];
-      if (count > 1) {
-        tdDia.rowSpan = count;
-        tdDia.classList.add('vertical-text');
-      }
-      tr.appendChild(tdDia);
-      lastData = p.Data;
-    }
-    const billar = (p.Billar || '').replace('Billar ', 'B');
-    [p.Hora || '', billar, (p['Jugador A'] || '').trim(), (p['Jugador B'] || '').trim()].forEach(val => {
-      const td = document.createElement('td');
-      td.textContent = val;
-      tr.appendChild(td);
+    const progFiltrades = programades.filter(p => {
+      if (!filtre) return true;
+      const j1 = (p['Jugador A'] || '').trim().toLowerCase();
+      const j2 = (p['Jugador B'] || '').trim().toLowerCase();
+      return j1.includes(filtre) || j2.includes(filtre);
     });
-    taula.appendChild(tr);
-  });
 
-  appendResponsiveTable(cont, taula);
+    const dayCounts = progFiltrades.reduce((acc, p) => {
+      acc[p.Data] = (acc[p.Data] || 0) + 1;
+      return acc;
+    }, {});
 
-  if (pendents.length > 0) {
-    const h3 = document.createElement('h3');
-    h3.textContent = 'Pendent de programar';
-    cont.appendChild(h3);
-
-    const taulaPend = document.createElement('table');
-    const capPend = document.createElement('tr');
-    ['Jornada', 'J1', 'J2'].forEach(t => {
+    const taula = document.createElement('table');
+    const cap = document.createElement('tr');
+    ['Dia', 'Hora', 'Billar', 'J1', 'J2'].forEach(t => {
       const th = document.createElement('th');
       th.textContent = t;
-      capPend.appendChild(th);
+      cap.appendChild(th);
     });
-    taulaPend.appendChild(capPend);
+    taula.appendChild(cap);
 
-    pendents
+    let lastData = null;
+    progFiltrades.forEach(p => {
+      const tr = document.createElement('tr');
+      if (p.Data !== lastData) {
+        const tdDia = document.createElement('td');
+        const [yyyy, mm, dd] = (p.Data || '').split('-');
+        const diaNum = parseInt(dd, 10);
+
+        const diaTxt = mm && diaNum ? `${diaNum}<br>${mesos[mm] || mm}` : '';
+        tdDia.innerHTML = diaTxt;
+
+        const count = dayCounts[p.Data];
+        if (count > 1) {
+          tdDia.rowSpan = count;
+          tdDia.classList.add('vertical-text');
+        }
+        tr.appendChild(tdDia);
+        lastData = p.Data;
+      }
+      const billar = (p.Billar || '').replace('Billar ', 'B');
+      [p.Hora || '', billar, (p['Jugador A'] || '').trim(), (p['Jugador B'] || '').trim()].forEach(val => {
+        const td = document.createElement('td');
+        td.textContent = val;
+        tr.appendChild(td);
+      });
+      taula.appendChild(tr);
+    });
+
+    appendResponsiveTable(dataContainer, taula);
+
+    const pendFiltrades = pendents
+      .filter(p => {
+        if (!filtre) return true;
+        const j1 = (p['Jugador A'] || '').trim().toLowerCase();
+        const j2 = (p['Jugador B'] || '').trim().toLowerCase();
+        return j1.includes(filtre) || j2.includes(filtre);
+      })
       .sort(
         (a, b) =>
           (parseInt(a.Jornada, 10) || 0) - (parseInt(b.Jornada, 10) || 0)
-      )
-      .forEach(p => {
+      );
+
+    if (pendFiltrades.length > 0) {
+      const h3 = document.createElement('h3');
+      h3.textContent = 'Pendent de programar';
+      dataContainer.appendChild(h3);
+
+      const taulaPend = document.createElement('table');
+      const capPend = document.createElement('tr');
+      ['Jornada', 'J1', 'J2'].forEach(t => {
+        const th = document.createElement('th');
+        th.textContent = t;
+        capPend.appendChild(th);
+      });
+      taulaPend.appendChild(capPend);
+
+      pendFiltrades.forEach(p => {
         const tr = document.createElement('tr');
         [
           p.Jornada || '',
@@ -880,8 +908,15 @@ function mostraCalendari(partides) {
         taulaPend.appendChild(tr);
       });
 
-    appendResponsiveTable(cont, taulaPend);
+      appendResponsiveTable(dataContainer, taulaPend);
+    }
   }
+
+  input.addEventListener('input', () => {
+    render(input.value.trim().toLowerCase());
+  });
+
+  render();
 }
 
 function mostraTorneig(dades, file) {

--- a/style.css
+++ b/style.css
@@ -126,7 +126,8 @@ button:active {
 
 #classificacio-year-select,
 #partides-categoria-select,
-#partides-player-filter {
+#partides-player-filter,
+#calendari-player-filter {
   border: 1px solid #ccc;
   border-radius: 4px;
   padding: 0.5rem;
@@ -154,6 +155,14 @@ button:active {
 }
 
 #partides-filters {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+#calendari-filters {
   margin-top: 0.5rem;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- allow filtering calendar matches by player name
- support substring search across both players
- match calendar player filter styling with results section

## Testing
- `node --check main.js`
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68933208d778832eb80092e10502f3bd