### PR TITLE
Fix classification view for ongoing social

### DIFF
--- a/main.js
+++ b/main.js
@@ -955,6 +955,7 @@ function mostraTorneig(dades, file) {
 
   // Format específic per als inscrits: array d'objectes amb categoria i nom
   if (
+    file !== 'classificacio.json' &&
     Array.isArray(dades) &&
     dades[0] &&
     (('Categoria jugador' in dades[0] && 'Nom jugador' in dades[0]) ||


### PR DESCRIPTION
## Summary
- Ensure the Social en curs classification view loads real rankings instead of showing registered players

## Testing
- `node --check main.js`
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689368cc9e50832e9688eafe3d4f7b3c