### PR TITLE
Display calendar hours without trailing minutes

### DIFF
--- a/main.js
+++ b/main.js
@@ -863,7 +863,12 @@ function mostraCalendari(partides) {
       }
       const billar = (p.Billar || '').replace('Billar ', 'B');
 
-      [p.Hora || '', billar, (p['Jugador A'] || '').trim(), (p['Jugador B'] || '').trim()].forEach(val => {
+      let hora = p.Hora || '';
+      if (/^\d{1,2}:00$/.test(hora)) {
+        hora = hora.split(':')[0];
+      }
+
+      [hora, billar, (p['Jugador A'] || '').trim(), (p['Jugador B'] || '').trim()].forEach(val => {
 
         const td = document.createElement('td');
         td.textContent = val;


### PR DESCRIPTION
## Summary
- trim ':00' from scheduled times in calendar view so `18:00` and `19:00` show as `18` and `19`

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68936a186b1c832eae70ff074bd1046a