### PR TITLE
Include social matches in agenda

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,9 +61,10 @@ function inicialitza() {
   Promise.all([
     fetch('ranquing.json').then(r => r.json()),
     fetch('classificacions.json').then(r => r.json()).catch(() => []),
-    fetch('events.json').then(r => r.json()).catch(() => [])
+    fetch('events.json').then(r => r.json()).catch(() => []),
+    fetch('data/calendari.json').then(r => r.json()).catch(() => [])
   ])
-    .then(([dadesRanking, dadesClass, dadesEvents]) => {
+    .then(([dadesRanking, dadesClass, dadesEvents, dadesCalendari]) => {
       ranquing = dadesRanking;
       anys = [...new Set(dadesRanking.map(d => parseInt(d.Any, 10)))]
         .sort((a, b) => a - b);
@@ -76,7 +77,13 @@ function inicialitza() {
       const categories = new Set(dadesClass.map(d => d.Categoria));
       classCategoriaSeleccionada = categories.values().next().value || null;
 
-      events = dadesEvents;
+      events = dadesEvents.concat(
+        dadesCalendari.map(p => ({
+          Data: p.Data,
+          Hora: '',
+          Títol: `${p['Jugador A'].trim()} vs ${p['Jugador B'].trim()} (${p.Hora})`
+        }))
+      );
 
       preparaSelectors();
       preparaSelectorsClassificacio();


### PR DESCRIPTION
## Summary
- include current social tournament matches in agenda view

## Testing
- `node --check main.js`
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_68936b628178832e87aa4d91af531dd2