### PR TITLE
Show weekly agenda with coloured events

### DIFF
--- a/style.css
+++ b/style.css
@@ -372,6 +372,36 @@ tr:nth-child(even) {
   cursor: pointer;
 }
 
+.calendar-table td.event-partida {
+  background: #d1c4e9;
+  cursor: pointer;
+}
+
+.calendar-table td.event-assemblea {
+  background: #fff59d;
+  cursor: pointer;
+}
+
+.agenda-table tr.event-inici td {
+  background: #c8e6c9;
+}
+
+.agenda-table tr.event-fi td {
+  background: #ffcdd2;
+}
+
+.agenda-table tr.event-other td {
+  background: #bbdefb;
+}
+
+.agenda-table tr.event-partida td {
+  background: #d1c4e9;
+}
+
+.agenda-table tr.event-assemblea td {
+  background: #fff59d;
+}
+
 .selected-event {
   background: #fff9c4 !important;
 }


### PR DESCRIPTION
## Summary
- Switch agenda from monthly to weekly view with start/end range label.
- Mark assemblies and match events so calendar and list rows use distinct colours.

## Testing
- `node --check main.js`
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689372f20e98832e89bb3ccb167c6348