### PR TITLE
Highlight matches with distinct color in weekly agenda

### DIFF
--- a/main.js
+++ b/main.js
@@ -375,12 +375,12 @@ function mostraAgenda() {
           cls = 'event-festiu';
         } else if (dayEvents.some(ev => ev.Tipus === 'assemblea')) {
           cls = 'event-assemblea';
+        } else if (dayEvents.some(ev => ev.Tipus === 'partida')) {
+          cls = 'event-partida';
         } else if (dayEvents.some(ev => ev['Títol'].includes('Fi'))) {
           cls = 'event-fi';
         } else if (dayEvents.some(ev => ev['Títol'].includes('Inici'))) {
           cls = 'event-inici';
-        } else if (dayEvents.some(ev => ev.Tipus === 'partida')) {
-          cls = 'event-partida';
         }
         cell.classList.add(cls);
         cell.addEventListener('click', () => highlightEvents(iso));
@@ -415,12 +415,12 @@ function mostraAgenda() {
         cls = 'event-festiu';
       } else if (ev.Tipus === 'assemblea') {
         cls = 'event-assemblea';
+      } else if (ev.Tipus === 'partida') {
+        cls = 'event-partida';
       } else if (ev['Títol'].includes('Fi')) {
         cls = 'event-fi';
       } else if (ev['Títol'].includes('Inici')) {
         cls = 'event-inici';
-      } else if (ev.Tipus === 'partida') {
-        cls = 'event-partida';
       }
       tr.classList.add(cls);
       ['Data', 'Hora', 'Títol'].forEach(clau => {

--- a/style.css
+++ b/style.css
@@ -372,13 +372,14 @@ table:not(.agenda-table) tr:nth-child(even) {
   cursor: pointer;
 }
 
+
 .calendar-table td.event-partida {
-  background: #d1c4e9;
+  background: #b39ddb;
   cursor: pointer;
 }
 
 .calendar-table td.event-assemblea {
-  background: #fff59d;
+  background: #ffeb3b;
   cursor: pointer;
 }
 
@@ -399,12 +400,13 @@ table:not(.agenda-table) tr:nth-child(even) {
   background: #bbdefb;
 }
 
+
 .agenda-table tr.event-partida td {
-  background: #d1c4e9;
+  background: #b39ddb;
 }
 
 .agenda-table tr.event-assemblea td {
-  background: #fff59d;
+  background: #ffeb3b;
 }
 
 .agenda-table tr.event-festiu td {


### PR DESCRIPTION
## Summary
- Prioritize match events in weekly agenda so they display with their own color even when other events occur the same day.
- Style matches in purple and assembly events in yellow for easier differentiation.

## Testing
- `node --check main.js`
- `python -m py_compile server.py tools/update_events.py`


------
https://chatgpt.com/codex/tasks/task_e_68937efab1ec832ebe50012bd52ee085