### PR TITLE
Format event dates and adjust table layout

### DIFF
--- a/main.js
+++ b/main.js
@@ -433,7 +433,12 @@ function mostraAgenda() {
       tr.classList.add(cls);
       ['Data', 'Títol'].forEach(clau => {
         const td = document.createElement('td');
-        td.textContent = ev[clau] || '';
+        if (clau === 'Data') {
+          const [y, m, d] = (ev['Data'] || '').split('-');
+          td.textContent = `${d}/${m}`;
+        } else {
+          td.textContent = ev[clau] || '';
+        }
         tr.appendChild(td);
       });
       listTable.appendChild(tr);

--- a/style.css
+++ b/style.css
@@ -272,6 +272,17 @@ td {
   text-align: left;
 }
 
+.agenda-table th:first-child,
+.agenda-table td:first-child {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.agenda-table th:last-child,
+.agenda-table td:last-child {
+  width: 99%;
+}
+
 
 th {
   background: var(--primary);


### PR DESCRIPTION
## Summary
- Show agenda dates in dd/mm format without the year
- Keep agenda table columns at consistent widths with a minimal date column

## Testing
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68938735bee8832ebb7362bbf810d99c