### PR TITLE
Allow event titles to wrap onto two lines

### DIFF
--- a/style.css
+++ b/style.css
@@ -283,6 +283,16 @@ td {
   width: 99%;
 }
 
+/* Allow event titles to wrap over two lines */
+.agenda-table td:last-child {
+  white-space: normal;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  word-break: break-word;
+}
+
 
 th {
   background: var(--primary);


### PR DESCRIPTION
## Summary
- Let long event titles wrap to a second line in the agenda view

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68938a8ae600832e901226b28cec7a17