### PR TITLE
Millora distintiu de finals i festius

### DIFF
--- a/main.js
+++ b/main.js
@@ -99,7 +99,7 @@ function inicialitza() {
           dadesFestius.map(f => ({
             Data: f.Data,
             Hora: '',
-            Títol: f.Títol || '',
+            Títol: `Foment tancat (${f.Títol || ''})`,
             Tipus: 'festiu'
           }))
         );

--- a/style.css
+++ b/style.css
@@ -8,11 +8,11 @@
   --background: #f9f9f9;
   --text-color: #222;
   --event-inici: #d1e7dd;
-  --event-fi: #f8d7da;
+  --event-fi: #f1aeb5;
   --event-other: #cfe2ff;
   --event-partida: #e2d9f3;
   --event-assemblea: #fff3cd;
-  --event-festiu: #f5c2c7;
+  --event-festiu: #e2e3e5;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Clarify holiday events by labeling them as "Foment tancat (festivitat)"
- Tune palette so end-of-registration and holiday days are easier to tell apart

## Testing
- `node --check main.js`
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6893a41a425c832e9dcfff3bc1a60278