### PR TITLE
Make player name filters case-insensitive

### DIFF
--- a/main.js
+++ b/main.js
@@ -730,6 +730,7 @@ function mostraPartides(partides) {
   cont.appendChild(list);
 
   function render(filtre = '') {
+    filtre = (filtre || '').toLowerCase();
     list.innerHTML = '';
     const filtered = partides
       .filter(p => p["🏆 Categoria de la partida"] === torneigCategoriaSeleccionada)
@@ -866,6 +867,7 @@ function mostraCalendari(partides) {
   };
 
   function render(filtre = '') {
+    filtre = (filtre || '').toLowerCase();
     dataContainer.innerHTML = '';
 
     const progFiltrades = programades.filter(p => {


### PR DESCRIPTION
## Summary
- Ensure partides and calendar filters convert search term to lower case for case-insensitive matching

## Testing
- `npm test` (fails: package.json missing)
- `python -m pytest` (no tests found)

------
https://chatgpt.com/codex/tasks/task_e_6893a74ec294832eacca89350bc8cb72