### PR TITLE
feat: enforce daily service worker updates

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,9 @@ if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./service-worker.js')
       .then(reg => {
         console.log('SW registrat!', reg);
+        // Força una comprovació d'actualitzacions diària
+        reg.update();
+        setInterval(() => reg.update(), 24 * 60 * 60 * 1000);
       })
       .catch(err => console.error('Error al registrar el SW:', err));
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.3/workbox-sw.js');
 
 // This value is replaced at build time by tools/update_sw_version.py
-const CACHE_VERSION = '20250805222138';
+const CACHE_VERSION = '20250808085201';
 
 // Activate new service worker as soon as it's finished installing
 workbox.core.skipWaiting();


### PR DESCRIPTION
## Summary
- trigger service worker `update()` every day to fetch new versions
- bump service worker cache version

## Testing
- `node --check main.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_6895ba1c4550832ea1bf946806f13483