### PR TITLE
Afegeix botó per forçar actualització de la PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
   </head>
   <body>
   <div id="app">
-    <h1><img src="icons/icon-192.png" alt="Logo" class="header-logo">Secció de Billar del Foment Martinenc</h1>
+    <h1>
+      <img src="icons/icon-192.png" alt="Logo" class="header-logo">Secció de Billar del Foment Martinenc
+      <button id="btn-update" aria-label="Actualitza" title="Actualitza">🔄</button>
+    </h1>
     <div id="menu">
     <button id="btn-agenda">Agenda Billar</button>
     <button id="btn-torneig">Social en curs</button>

--- a/main.js
+++ b/main.js
@@ -18,6 +18,20 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+document.getElementById('btn-update').addEventListener('click', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistration().then(reg => {
+      if (reg) {
+        reg.update().then(() => {
+          if (reg.waiting) {
+            reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+          }
+        });
+      }
+    });
+  }
+});
+
 let ranquing = [];
 let anys = [];
 let anySeleccionat = null;

--- a/style.css
+++ b/style.css
@@ -41,6 +41,23 @@ h1 {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  position: relative;
+  }
+
+#btn-update {
+  position: absolute;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+#btn-update:hover {
+  color: #ddd;
 }
 
 .header-logo {


### PR DESCRIPTION
## Summary
- Botó de refresc afegit al costat del títol per forçar l'actualització de la PWA
- Estils nous per situar i mostrar la icona de refresc
- La pulsació del botó desencadena l'actualització del service worker

## Testing
- `npm test` (falla: no es troba package.json)
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6895cc5144c0832e977e36d1ff705119