### PR TITLE
Add prohibition card to Normativa i Horari page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ python3 tools/update_sw_version.py
 
 - Netejar taula i boles abans de començar amb el material que la secció posa a disposició dels socis.
 
+### Prohibit
+
+- Jugar a fantasia.
+- Menjar a les sales.
+- Posar begudes sobre cap element del billar.
+
 ### Inscripció a les partides
 
 - Apunta’t a la pissarra única de **PARTIDES SOCIALS**.

--- a/main.js
+++ b/main.js
@@ -506,6 +506,16 @@ function mostraHorari() {
     </p>
   </div>
 
+  <!-- Prohibicions -->
+  <div class="normes-card prohibit">
+    <h3>🚫 Prohibit</h3>
+    <ul>
+      <li>Jugar a fantasia.</li>
+      <li>Menjar a les sales.</li>
+      <li>Posar begudes sobre cap element del billar.</li>
+    </ul>
+  </div>
+
   <!-- Inscripció -->
   <div class="normes-card">
     <h3>📝 Inscripció a les partides</h3>

--- a/style.css
+++ b/style.css
@@ -544,6 +544,15 @@ details summary {
   color: #d90000;
 }
 
+.normes-card.prohibit {
+  background: var(--event-fi);
+  border: 2px solid #ff4d4d;
+}
+
+.normes-card.prohibit h3 {
+  color: #d90000;
+}
+
 .normes-card ul {
   margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- Add prohibition card detailing bans on playing fantasia, eating in rooms, and placing drinks on billiard equipment.
- Style new prohibition card consistently with existing norms page.
- Document new prohibitions in README.

## Testing
- `node --check main.js`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68988a3cdf00832ea2075173d6cf8e14