### PR TITLE
Add prohibition card to Normativa i Horari page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,15 @@ python3 tools/update_sw_version.py
 
 *L’horari pot canviar.*
 
-### OBLIGATORI
+### ✅ OBLIGATORI
 
-- Netejar taula i boles abans de començar amb el material que la secció posa a disposició dels socis.
+- Netejar el billar i les boles abans de començar cada partida amb el material que la Secció posa a disposició de tots els socis.
+
+### 🚫 Prohibit
+
+- Jugar a fantasia.
+- Menjar a les sales.
+- Posar begudes sobre cap element del billar.
 
 ### Inscripció a les partides
 

--- a/main.js
+++ b/main.js
@@ -500,10 +500,20 @@ function mostraHorari() {
 
   <!-- Norma Obligatòria -->
   <div class="normes-card obligatori">
-    <h3>🚨 OBLIGATORI</h3>
+    <h3>✅ OBLIGATORI</h3>
     <p class="obligatori-text">
-      Netejar taula i boles abans de començar amb el material que la secció posa a disposició dels socis.
+      Netejar el billar i les boles abans de començar cada partida amb el material que la Secció posa a disposició de tots els socis.
     </p>
+  </div>
+
+  <!-- Prohibicions -->
+  <div class="normes-card prohibit">
+    <h3>🚫 Prohibit</h3>
+    <ul>
+      <li>Jugar a fantasia.</li>
+      <li>Menjar a les sales.</li>
+      <li>Posar begudes sobre cap element del billar.</li>
+    </ul>
   </div>
 
   <!-- Inscripció -->

--- a/style.css
+++ b/style.css
@@ -536,11 +536,20 @@ details summary {
 }
 
 .normes-card.obligatori {
+  background: var(--event-inici);
+  border: 2px solid #28a745;
+}
+
+.normes-card.obligatori h3 {
+  color: #1e7e34;
+}
+
+.normes-card.prohibit {
   background: var(--event-fi);
   border: 2px solid #ff4d4d;
 }
 
-.normes-card.obligatori h3 {
+.normes-card.prohibit h3 {
   color: #d90000;
 }
 
@@ -558,6 +567,7 @@ details summary {
   font-size: 1.1em;
   font-weight: bold;
   margin: 0;
+  text-align: center;
 }
 
 


### PR DESCRIPTION
## Summary
- Add prohibition card detailing bans on playing fantasia, eating in rooms, and placing drinks on billiard equipment.
- Style cards so obligations use a green theme with a check mark icon, distinguishing them from red prohibition cards.
- Update obligation card to remind players to clean the billiard table and balls before each match, with bold centered text for emphasis.
- Document new prohibitions and refreshed obligation text in README.

## Testing
- `node --check main.js`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68988a3cdf00832ea2075173d6cf8e14