### PR TITLE
Detalla notes sobre l'horari d'obertura

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ python3 tools/update_sw_version.py
 - Dilluns, dimecres, dijous, dissabte i diumenge: 9:00 – 21:30
 - Dimarts i divendres: 10:30 – 21:30
 
-*L’horari pot canviar.*
+\*L'horari d'obertura pot canviar en funció dels horaris d'obertura del Bar del Foment.  
+\*\*L'horari del Foment és de dilluns a divendres de 9:00 a 13:00 i de 16:00 a 20:00. Agost i festius tancat.
 
 ### ✅ OBLIGATORI
 

--- a/main.js
+++ b/main.js
@@ -493,9 +493,10 @@ function mostraHorari() {
       <li><b>Dilluns, dimecres, dijous, dissabte i diumenge:</b> 9:00 – 21:30</li>
       <li><b>Dimarts i divendres:</b> 10:30 – 21:30</li>
     </ul>
-    <p class="normes-note">
-      *L’horari pot canviar.
-    </p>
+      <p class="normes-note">
+        *L'horari d'obertura pot canviar en funció dels horaris d'obertura del Bar del Foment.<br>
+        **L'horari del Foment és de dilluns a divendres de 9:00 a 13:00 i de 16:00 a 20:00. Agost i festius tancat.
+      </p>
   </div>
 
   <!-- Norma Obligatòria -->


### PR DESCRIPTION
## Summary
- Amplia la nota de l'horari per indicar que depèn de l'obertura del Bar del Foment.
- Afegeix l'horari general del Foment a la documentació.

## Testing
- `node --check main.js`
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6898939be0a4832e88cf952cc917170e