### PR TITLE
feat: auto update service worker

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,9 +3,18 @@ if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('./service-worker.js')
       .then(reg => {
         console.log('SW registrat!', reg);
+        // Comprova si hi ha una versió nova i aplica-la immediatament
+        const checkForUpdate = () => {
+          reg.update().then(() => {
+            if (reg.waiting) {
+              reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+            }
+          });
+        };
+
+        checkForUpdate();
         // Força una comprovació d'actualitzacions diària
-        reg.update();
-        setInterval(() => reg.update(), 24 * 60 * 60 * 1000);
+        setInterval(checkForUpdate, 24 * 60 * 60 * 1000);
       })
       .catch(err => console.error('Error al registrar el SW:', err));
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,9 +3,7 @@ importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.3/workbox
 // This value is replaced at build time by tools/update_sw_version.py
 const CACHE_VERSION = '20250808085201';
 
-// Activate new service worker as soon as it's finished installing
-workbox.core.skipWaiting();
-workbox.core.clientsClaim();
+self.addEventListener('install', () => self.skipWaiting());
 
 self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'SKIP_WAITING') {
@@ -16,9 +14,11 @@ self.addEventListener('message', (event) => {
 // Notify clients when a new version of the service worker is active
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    self.clients.matchAll({ type: 'window' }).then((clients) => {
-      clients.forEach((client) => client.postMessage({ type: 'NEW_VERSION' }));
-    })
+    (async () => {
+      await self.clients.claim();
+      const clientList = await self.clients.matchAll({ type: 'window' });
+      clientList.forEach((client) => client.postMessage({ type: 'NEW_VERSION' }));
+    })()
   );
 });
 


### PR DESCRIPTION
## Summary
- force service worker to skip waiting on install and claim clients on activation
- auto check for updates and apply new service worker immediately

## Testing
- `node --check service-worker.js && echo 'SW OK'`
- `node --check main.js && echo 'MAIN OK'`


------
https://chatgpt.com/codex/tasks/task_e_68989d83a37c832e90cb3d51206aa830