### PR TITLE
feat: sync events from google sheet

### DIFF
--- a/.github/workflows/update-jsons.yml
+++ b/.github/workflows/update-jsons.yml
@@ -6,37 +6,40 @@ on:
     - cron: '0 21 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-jsons
+  cancel-in-progress: false
+
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
+          python-version: '3.12'
+
       - name: Run update scripts
-        run: |
-          python update_classificacions.py
-          python update_ranquing.py
-          python update_events.py
-
-
-      - name: Commit and push changes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AGENDA_SHEET_ID: "1IkA50UI7OpFd_VYUb5kNe9V0jj-MZKqu"
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if [ -n "$(git status --porcelain)" ]; then
+          python tools/update_classificacions.py
+          python tools/update_ranquing.py
+          python tools/update_events.py
 
+      - name: Commit & push if changed
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add classificacions.json ranquing.json events.json
-
-
-            git commit -m "Update JSON files"
+            git commit -m "chore(data): refresh JSON files [skip ci]"
             git push
           else
             echo "No changes to commit"

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ python3 server.py
 Aquesta ordre arrenca un petit servidor web a `http://localhost:8000`.
 La informació de rànquing i classificacions s'ha d'actualitzar
 externament mitjançant una aplicació d'escriptori. De la mateixa manera,
-els esdeveniments s'obtenen de `agenda.xlsx` executant:
+els esdeveniments es sincronitzen d'un Google Sheet públic executant:
 
 ```bash
-python3 update_events.py
+AGENDA_SHEET_ID=1IkA50UI7OpFd_VYUb5kNe9V0jj-MZKqu python3 tools/update_events.py
 ```
 
 ### Actualitzar la versió del service worker

--- a/server.py
+++ b/server.py
@@ -11,7 +11,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.path == '/update-ranking':
             try:
-                subprocess.run(['python3', 'update_ranquing.py'], check=True)
+                subprocess.run(['python3', 'tools/update_ranquing.py'], check=True)
                 self.send_response(200)
                 self.send_header('Content-Type', 'application/json')
                 self.end_headers()
@@ -22,7 +22,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             return
         if self.path == '/update-classificacions':
             try:
-                subprocess.run(['python3', 'update_classificacions.py'], check=True)
+                subprocess.run(['python3', 'tools/update_classificacions.py'], check=True)
                 self.send_response(200)
                 self.send_header('Content-Type', 'application/json')
                 self.end_headers()
@@ -33,7 +33,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             return
         if self.path == '/update-events':
             try:
-                subprocess.run(['python3', 'update_events.py'], check=True)
+                subprocess.run(['python3', 'tools/update_events.py'], check=True)
                 self.send_response(200)
                 self.send_header('Content-Type', 'application/json')
                 self.end_headers()


### PR DESCRIPTION
## Summary
- fetch agenda events from a public Google Sheet using the OpenSheet service
- document new update_events usage with AGENDA_SHEET_ID
- schedule JSON refresh workflow to run updated scripts and supply agenda sheet ID
- fix local update endpoints to call scripts from the tools directory

## Testing
- `AGENDA_SHEET_ID=1IkA50UI7OpFd_VYUb5kNe9V0jj-MZKqu python3 tools/update_events.py` *(failed: Failed to GET https://opensheet.elk.sh/1IkA50UI7OpFd_VYUb5kNe9V0jj-MZKqu/1: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_6898af8f90c4832ea11d17e9f7862a34