### PR TITLE
Use OpenSheet IDs for update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ externament mitjançant una aplicació d'escriptori. De la mateixa manera,
 els esdeveniments es sincronitzen d'un Google Sheet públic executant:
 
 ```bash
-AGENDA_SHEET_ID=1IkA50UI7OpFd_VYUb5kNe9V0jj-MZKqu python3 tools/update_events.py
+AGENDA_ID=1IkA50UI7OpFd_VYUb5kNe9V0jj-MZKqu python3 tools/update_events.py
 ```
 
 ### Actualitzar la versió del service worker

--- a/tools/update_enllacos.py
+++ b/tools/update_enllacos.py
@@ -6,13 +6,13 @@ content changed. Environment variables allow customisation, similar to
 `update_sheets.py`.
 
 Required env vars:
-  • LINKS_SHEET_ID – Google Sheet identifier
+  • SHEETS_ID   – Google Sheet identifier
 
 Optional env vars:
-  • LINKS_SHEET_TAB – sheet tab name or index (default: "1")
-  • OUTPUT_FILE     – path of the JSON file (default: "enllacos.json")
-  • HTTP_TIMEOUT    – request timeout in seconds (default: 30)
-  • HTTP_RETRIES    – number of fetch retries (default: 5)
+  • SHEETS_TAB  – sheet tab name or index (default: "1")
+  • OUTPUT_FILE – path of the JSON file (default: "enllacos.json")
+  • HTTP_TIMEOUT – request timeout in seconds (default: 30)
+  • HTTP_RETRIES – number of fetch retries (default: 5)
 """
 
 from __future__ import annotations
@@ -29,8 +29,8 @@ import urllib.request
 from typing import Any
 
 BASE = "https://opensheet.elk.sh"
-SHEET_ID = os.getenv("LINKS_SHEET_ID", "").strip()
-SHEET_TAB = os.getenv("LINKS_SHEET_TAB", "1").strip() or "1"
+SHEET_ID = os.getenv("SHEETS_ID", "").strip()
+SHEET_TAB = os.getenv("SHEETS_TAB", "1").strip() or "1"
 OUTPUT_FILE = pathlib.Path(os.getenv("OUTPUT_FILE", "enllacos.json"))
 TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "30"))
 MAX_RETRIES = int(os.getenv("HTTP_RETRIES", "5"))
@@ -78,7 +78,7 @@ def write_if_changed(path: pathlib.Path, data_obj: Any) -> bool:
 def main() -> None:
     if not SHEET_ID:
         print(
-            "ERROR: variable d'entorn LINKS_SHEET_ID no definida.",
+            "ERROR: variable d'entorn SHEETS_ID no definida.",
             file=sys.stderr,
         )
         sys.exit(2)

--- a/tools/update_events.py
+++ b/tools/update_events.py
@@ -5,13 +5,13 @@ Fetches rows via the OpenSheet service and writes a JSON file only if
 content changed.  Inspired by ``update_enllacos.py``.
 
 Required env vars:
-  • AGENDA_SHEET_ID – Google Sheet identifier
+  • AGENDA_ID    – Google Sheet identifier
 
 Optional env vars:
-  • AGENDA_SHEET_TAB – sheet tab name or index (default: "1")
-  • OUTPUT_FILE      – path of the JSON file (default: "events.json")
-  • HTTP_TIMEOUT     – request timeout in seconds (default: 30)
-  • HTTP_RETRIES     – number of fetch retries (default: 5)
+  • AGENDA_TAB   – sheet tab name or index (default: "1")
+  • OUTPUT_FILE  – path of the JSON file (default: "events.json")
+  • HTTP_TIMEOUT – request timeout in seconds (default: 30)
+  • HTTP_RETRIES – number of fetch retries (default: 5)
 """
 
 from __future__ import annotations
@@ -29,8 +29,8 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 BASE = "https://opensheet.elk.sh"
-SHEET_ID = os.getenv("AGENDA_SHEET_ID", "").strip()
-SHEET_TAB = os.getenv("AGENDA_SHEET_TAB", "1").strip() or "1"
+SHEET_ID = os.getenv("AGENDA_ID", "").strip()
+SHEET_TAB = os.getenv("AGENDA_TAB", "1").strip() or "1"
 OUTPUT_FILE = pathlib.Path(os.getenv("OUTPUT_FILE", "events.json"))
 TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "30"))
 MAX_RETRIES = int(os.getenv("HTTP_RETRIES", "5"))
@@ -104,7 +104,7 @@ def normalise_rows(payload: List[Dict[str, str]]) -> List[Dict[str, str]]:
 def main() -> None:
     if not SHEET_ID:
         print(
-            "ERROR: variable d'entorn AGENDA_SHEET_ID no definida.",
+            "ERROR: variable d'entorn AGENDA_ID no definida.",
             file=sys.stderr,
         )
         sys.exit(2)

--- a/tools/update_ranquing.py
+++ b/tools/update_ranquing.py
@@ -1,61 +1,124 @@
-import zipfile
-import xml.etree.ElementTree as ET
+#!/usr/bin/env python3
+"""Sync ranking data from a Google Sheet via OpenSheet.
+
+Fetches rows from the spreadsheet identified by ``RANK_ID`` and writes
+``ranquing.json`` only when content changes.
+
+Required environment variables:
+    • RANK_ID       – Google Sheet identifier
+
+Optional environment variables:
+    • RANK_TAB      – sheet tab name or index (default: "1")
+    • OUTPUT_FILE   – path of the JSON file (default: "ranquing.json")
+    • HTTP_TIMEOUT  – request timeout in seconds (default: 30)
+    • HTTP_RETRIES  – number of fetch retries (default: 5)
+"""
+
+from __future__ import annotations
+
+import hashlib
 import json
-from pathlib import Path
+import os
+import pathlib
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List
 
-XLSX_FILE = Path('Ranquing.xlsx')
-JSON_FILE = Path('ranquing.json')
+BASE = "https://opensheet.elk.sh"
+SHEET_ID = os.getenv("RANK_ID", "").strip()
+SHEET_TAB = os.getenv("RANK_TAB", "1").strip() or "1"
+OUTPUT_FILE = pathlib.Path(os.getenv("OUTPUT_FILE", "ranquing.json"))
+TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "30"))
+MAX_RETRIES = int(os.getenv("HTTP_RETRIES", "5"))
 
-NS = {'a': 'http://schemas.openxmlformats.org/spreadsheetml/2006/main'}
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (compatible; RanquingSync/1.0; +https://github.com/<repo>)"
+    ),
+    "Accept": "application/json",
+}
 
-def load_shared_strings(z):
-    data = z.read('xl/sharedStrings.xml')
-    tree = ET.fromstring(data)
-    strings = []
-    for t in tree.findall('.//a:t', NS):
-        strings.append(t.text or '')
-    return strings
 
-def cell_value(cell, strings):
-    v = cell.find('a:v', NS)
-    if v is None:
-        return ''
-    val = v.text or ''
-    if cell.get('t') == 's':
-        idx = int(val)
-        return strings[idx]
-    return val
+def fetch_json(url: str, tries: int = MAX_RETRIES, timeout: int = TIMEOUT) -> Any:
+    """GET helper with custom headers and exponential backoff."""
+    last_err: Exception | None = None
+    for i in range(tries):
+        try:
+            req = urllib.request.Request(url, headers=HEADERS)
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                charset = resp.headers.get_content_charset() or "utf-8"
+                return json.loads(resp.read().decode(charset))
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+            last_err = e
+            if isinstance(e, urllib.error.HTTPError) and e.code == 403:
+                break
+            time.sleep(2**i)
+    raise RuntimeError(f"Failed to GET {url}: {last_err}") from last_err
 
-def update():
-    with zipfile.ZipFile(XLSX_FILE) as z:
-        strings = load_shared_strings(z)
-        sheet_xml = z.read('xl/worksheets/sheet1.xml')
-    sheet = ET.fromstring(sheet_xml)
-    sheet_data = sheet.find('a:sheetData', NS)
-    rows = []
-    for row in sheet_data.findall('a:row', NS):
-        r_index = int(row.get('r'))
-        if r_index == 1:
-            continue  # header
-        cells = {c.get('r')[0]: c for c in row.findall('a:c', NS)}
+
+def write_if_changed(path: pathlib.Path, data_obj: Any) -> bool:
+    """Write JSON file only when content changes (SHA-256 check)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    new_bytes = json.dumps(data_obj, ensure_ascii=False, sort_keys=True).encode(
+        "utf-8"
+    )
+    if path.exists() and hashlib.sha256(path.read_bytes()).digest() == hashlib.sha256(
+        new_bytes
+    ).digest():
+        return False
+    path.write_bytes(new_bytes)
+    return True
+
+
+def normalise_rows(payload: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    rows: List[Dict[str, str]] = []
+    for row in payload:
         record = {
-            'Any': cell_value(cells.get('A', ET.Element('c')), strings),
-            'Modalitat': cell_value(cells.get('B', ET.Element('c')), strings),
-            'Posició': cell_value(cells.get('C', ET.Element('c')), strings),
-            'Jugador': cell_value(cells.get('D', ET.Element('c')), strings),
-            'Mitjana': cell_value(cells.get('E', ET.Element('c')), strings),
-            'Soci': cell_value(cells.get('F', ET.Element('c')), strings),
-            'Nom': cell_value(cells.get('G', ET.Element('c')), strings),
-            'Cognom1': cell_value(cells.get('H', ET.Element('c')), strings),
-            'Cognom2': cell_value(cells.get('I', ET.Element('c')), strings),
+            "Any": row.get("Any", ""),
+            "Modalitat": row.get("Modalitat", ""),
+            "Posició": row.get("Posició") or row.get("Posicio", ""),
+            "Jugador": row.get("Jugador", ""),
+            "Mitjana": row.get("Mitjana", ""),
+            "Soci": row.get("Soci", ""),
+            "Nom": row.get("Nom", ""),
+            "Cognom1": row.get("Cognom1", ""),
+            "Cognom2": row.get("Cognom2", ""),
         }
-        noms = [record.get('Nom', '').strip(),
-                record.get('Cognom1', '').strip(),
-                record.get('Cognom2', '').strip()]
-        nom_complet = ' '.join([n for n in noms if n])
-        record['NomComplet'] = nom_complet if nom_complet else record['Jugador']
-        rows.append(record)
-    JSON_FILE.write_text(json.dumps(rows, ensure_ascii=False, indent=2))
+        noms = [record.get("Nom", "").strip(),
+                record.get("Cognom1", "").strip(),
+                record.get("Cognom2", "").strip()]
+        nom_complet = " ".join([n for n in noms if n])
+        record["NomComplet"] = nom_complet if nom_complet else record["Jugador"]
+        if any(record.values()):
+            rows.append(record)
+    return rows
 
-if __name__ == '__main__':
-    update()
+
+def main() -> None:
+    if not SHEET_ID:
+        print(
+            "ERROR: variable d'entorn RANK_ID no definida.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    url = f"{BASE}/{SHEET_ID}/{urllib.parse.quote(SHEET_TAB, safe='')}"
+    try:
+        payload = fetch_json(url)
+    except Exception as e:
+        print(f"Avís: error baixant dades: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    data = normalise_rows(payload if isinstance(payload, list) else [])
+    if write_if_changed(OUTPUT_FILE, data):
+        print(f"Fitxer actualitzat: {OUTPUT_FILE}")
+    else:
+        print("Sense canvis.")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- fetch classificacions and ranquing data from Google Sheets via OpenSheet using `CLAS_ID` and `RANK_ID`
- standardise update scripts to environment variables `AGENDA_ID` and `SHEETS_ID`
- document new environment variable name for updating events

## Testing
- `python -m py_compile tools/update_classificacions.py tools/update_ranquing.py tools/update_events.py tools/update_enllacos.py`


------
https://chatgpt.com/codex/tasks/task_e_6898be8e4c84832e8277044c8c767f6f