### PR TITLE
chore(ci): use secrets for Google Sheet IDs

### DIFF
--- a/.github/workflows/update-jsons.yml
+++ b/.github/workflows/update-jsons.yml
@@ -27,7 +27,9 @@ jobs:
 
       - name: Run update scripts
         env:
-          AGENDA_SHEET_ID: "1IkA50UI7OpFd_VYUb5kNe9V0jj-MZKqu"
+          CLAS_ID: ${{ secrets.CLAS_ID }}
+          RANK_ID: ${{ secrets.RANK_ID }}
+          AGENDA_ID: ${{ secrets.AGENDA_ID }}
         run: |
           python tools/update_classificacions.py
           python tools/update_ranquing.py

--- a/.github/workflows/update-links.yml
+++ b/.github/workflows/update-links.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Run updater
         env:
-          LINKS_SHEET_ID: "11OYEE5abd8l5jrgJRcSOmvzE5vhYJCgkBIJpgEPS43k"
-          LINKS_SHEET_TAB: "1"
+          SHEETS_ID: ${{ secrets.SHEETS_ID }}
+          SHEETS_TAB: "1"
           OUTPUT_FILE: "enllacos.json"
         run: |
           python tools/update_enllacos.py

--- a/.github/workflows/update-sheets.yml
+++ b/.github/workflows/update-sheets.yml
@@ -31,7 +31,7 @@ jobs:
       # 3) Executa l’script d’actualització
       - name: Run updater
         env:
-          SHEET_ID: "1Dc01H5hAxPwwhyY_GnRAVFP2-uINanwJS1jhtFs2syU"      # ← posa'l a Settings → Secrets
+          SHEET_ID: ${{ secrets.SHEET_ID }}          # ← defineix-lo a Secrets
           SHEET_TABS: "1,2,3,4,5"                  # índexs o noms separats per comes
           OUTPUT_DIR: "data"              # carpeta on vols els .json
         run: |


### PR DESCRIPTION
## Summary
- load Google Sheet IDs from repository secrets in all updater workflows

## Testing
- `python -m py_compile tools/update_sheets.py tools/update_classificacions.py tools/update_ranquing.py tools/update_events.py tools/update_enllacos.py`


------
https://chatgpt.com/codex/tasks/task_e_6898c1c58ce4832ebbb93dc16cb0cc7c