### PR TITLE
Add caching worker for OpenSheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ This repo mirrors a public Google Sheet to JSON files.
 ```bash
 SHEET_ID=... SHEET_TABS=1,2,3,4,5 OUTPUT_DIR=data python3 tools/update_sheets.py
 ```
-Notes: the sheet must be public and OpenSheet caches ~30 s.  
-The script already uses a friendly User-Agent to avoid most 403 errors.  
+Notes: the sheet must be public and OpenSheet caches ~30 s.
+The script already uses a friendly User-Agent to avoid most 403 errors.
 Set `FORCE_IPV4=1` if your network only allows IPv4.
+
+### Optional caching proxy
+
+To avoid rate limits from `opensheet.elk.sh`, you can deploy the
+[`opensheet-worker.js`](./opensheet-worker.js) on Cloudflare Workers (or
+similar) which proxies requests and caches them for an hour. Point the
+tools to this worker by setting `OPENSHEET_BASE`:
+
+```bash
+OPENSHEET_BASE=https://your-worker.example.com SHEET_ID=... python3 tools/update_sheets.py
+```
+
+The same environment variable also works with `update_enllacos.py`.

--- a/opensheet-worker.js
+++ b/opensheet-worker.js
@@ -1,0 +1,25 @@
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    // Proxy path and query to the upstream OpenSheet service
+    const upstream = 'https://opensheet.elk.sh' + url.pathname + url.search;
+    const cache = caches.default;
+    const cacheKey = new Request(upstream, request);
+
+    let response = await cache.match(cacheKey);
+    if (!response) {
+      response = await fetch(upstream, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; FomentWorker/1.0; +https://github.com/<repo>)',
+          'Accept': 'application/json',
+        },
+      });
+      // Cache for one hour
+      const cacheControl = 'public, max-age=3600';
+      response = new Response(response.body, response);
+      response.headers.set('Cache-Control', cacheControl);
+      ctx.waitUntil(cache.put(cacheKey, response.clone()));
+    }
+    return response;
+  },
+};

--- a/tools/update_enllacos.py
+++ b/tools/update_enllacos.py
@@ -33,7 +33,8 @@ if os.getenv("DISABLE_PROXY", "1") != "0":
     for key in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.pop(key, None)
 
-BASE = "https://opensheet.elk.sh"
+# Allow overriding the OpenSheet endpoint, e.g. via a caching worker.
+BASE = os.getenv("OPENSHEET_BASE", "https://opensheet.elk.sh").rstrip("/")
 SHEET_ID = os.getenv("LINKS_SHEET_ID", "").strip()
 SHEET_TAB = os.getenv("LINKS_SHEET_TAB", "1").strip() or "1"
 OUTPUT_FILE = pathlib.Path(os.getenv("OUTPUT_FILE", "enllacos.json"))

--- a/tools/update_sheets.py
+++ b/tools/update_sheets.py
@@ -15,7 +15,8 @@ import urllib.parse
 import urllib.request
 from typing import Any, Iterable, List
 
-BASE = "https://opensheet.elk.sh"
+# Allow using a caching proxy for OpenSheet. Defaults to the public service.
+BASE = os.getenv("OPENSHEET_BASE", "https://opensheet.elk.sh").rstrip("/")
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (compatible; SheetSync/1.1; +https://github.com/<repo>)",
     "Accept": "application/json",


### PR DESCRIPTION
## Summary
- add Cloudflare Worker to proxy and cache requests to OpenSheet
- allow tools to override OpenSheet base URL via `OPENSHEET_BASE`
- document optional worker usage in README

## Testing
- `python3 -m py_compile tools/update_sheets.py tools/update_enllacos.py`
- `node --check opensheet-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68990dbaa31c832eb3e0c989e6f22563