### PR TITLE
Use LINKS_ID variable for link sync script

### DIFF
--- a/tools/update_enllacos.py
+++ b/tools/update_enllacos.py
@@ -3,10 +3,10 @@
 
 Fetches data via the OpenSheet service and writes a JSON file only if
 content changed. Environment variables allow customisation, similar to
-`update_sheets.py`.
+`tools/update_sheets.py`.
 
 Required env vars:
-  • LINKS_SHEET_ID – Google Sheet identifier
+  • LINKS_ID – Google Sheet identifier
 
 Optional env vars:
   • LINKS_SHEET_TAB – sheet tab name or index (default: "1")
@@ -35,7 +35,7 @@ if os.getenv("DISABLE_PROXY", "1") != "0":
 
 # Allow overriding the OpenSheet endpoint, e.g. via a caching worker.
 BASE = os.getenv("OPENSHEET_BASE", "https://opensheet.elk.sh").rstrip("/")
-SHEET_ID = os.getenv("LINKS_SHEET_ID", "").strip()
+SHEET_ID = os.getenv("LINKS_ID", "").strip()
 SHEET_TAB = os.getenv("LINKS_SHEET_TAB", "1").strip() or "1"
 OUTPUT_FILE = pathlib.Path(os.getenv("OUTPUT_FILE", "enllacos.json"))
 TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "30"))
@@ -84,7 +84,7 @@ def write_if_changed(path: pathlib.Path, data_obj: Any) -> bool:
 def main() -> None:
     if not SHEET_ID:
         print(
-            "ERROR: variable d'entorn LINKS_SHEET_ID no definida.",
+            "ERROR: variable d'entorn LINKS_ID no definida.",
             file=sys.stderr,
         )
         sys.exit(2)


### PR DESCRIPTION
## Summary
- Switch link update script to look for `LINKS_ID` instead of `LINKS_SHEET_ID`
- Update associated error message and documentation
- Clarify reference to the shared `tools/update_sheets.py` script

## Testing
- `python3 -m py_compile tools/update_enllacos.py`
- `LINKS_ID=test python3 tools/update_enllacos.py` *(network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899ab8b1b00832e9ede2c77d3c8e23b