### PR TITLE
Fix agenda event title parsing

### DIFF
--- a/main.js
+++ b/main.js
@@ -109,10 +109,14 @@ function inicialitza() {
       classCategoriaSeleccionada = categories.values().next().value || null;
 
       events = dadesEvents
-        .map(ev => ({
-          ...ev,
-          Tipus: ev['Títol'].toLowerCase().includes('assemblea') ? 'assemblea' : 'altre'
-        }))
+        .map(ev => {
+          const titol = ev['Títol'] || ev['Titol'] || '';
+          return {
+            ...ev,
+            'Títol': titol,
+            Tipus: titol.toLowerCase().includes('assemblea') ? 'assemblea' : 'altre'
+          };
+        })
         .concat(
           dadesCalendari.map(p => ({
             Data: p.Data,


### PR DESCRIPTION
## Summary
- Handle events using either `Titol` or `Títol` keys so agenda loads correctly

## Testing
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689a09857680832eb57b123de04afc33