### PR TITLE
Afegir submenús al menú principal

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,12 +15,32 @@
       <button id="btn-update" aria-label="Actualitza" title="Actualitza">🔄</button>
     </h1>
     <div id="menu">
-    <button id="btn-agenda">Agenda Billar</button>
-    <button id="btn-torneig">Social en curs</button>
-    <button id="btn-ranking">Rànquings Històric</button>
-    <button id="btn-classificacio">Històric Classif.</button>
-    <button id="btn-horari">Normativa i Horari</button>
-    <button id="btn-enllacos">Enllaços Billar</button>
+    <div class="menu-group">
+      <button class="menu-toggle" data-target="submenu-billar">Secció Billar</button>
+      <div id="submenu-billar" class="submenu">
+        <button id="btn-agenda">Agenda Billar</button>
+        <button id="btn-horari">Normativa i Horari</button>
+      </div>
+    </div>
+    <div class="menu-group">
+      <button class="menu-toggle" data-target="submenu-campionats">Campionats en curs</button>
+      <div id="submenu-campionats" class="submenu">
+        <button id="btn-torneig">Social en curs</button>
+      </div>
+    </div>
+    <div class="menu-group">
+      <button class="menu-toggle" data-target="submenu-historic">Històric</button>
+      <div id="submenu-historic" class="submenu">
+        <button id="btn-ranking">Rànquings</button>
+        <button id="btn-classificacio">Classificacions Socials</button>
+      </div>
+    </div>
+    <div class="menu-group">
+      <button class="menu-toggle" data-target="submenu-multimedia">Multimedia</button>
+      <div id="submenu-multimedia" class="submenu">
+        <button id="btn-enllacos">Enllaços Billar</button>
+      </div>
+    </div>
     <div id="filters-row" style="display:none">
       <select id="year-select"></select>
       <div id="modalitat-buttons" class="button-group secondary-buttons">

--- a/main.js
+++ b/main.js
@@ -1306,6 +1306,23 @@ function mostraTorneig(dades, file) {
   cont.appendChild(pre);
 }
 
+document.querySelectorAll('.menu-toggle').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const target = document.getElementById(btn.dataset.target);
+    const isVisible = target.style.display === 'flex';
+    document.querySelectorAll('.submenu').forEach(sm => {
+      sm.style.display = 'none';
+    });
+    target.style.display = isVisible ? 'none' : 'flex';
+    document.getElementById('filters-row').style.display = 'none';
+    document.getElementById('classificacio-filters').style.display = 'none';
+    document.getElementById('torneig-buttons').style.display = 'none';
+    document.getElementById('torneig-title').style.display = 'none';
+    document.getElementById('torneig-category-buttons').style.display = 'none';
+    document.getElementById('content').style.display = 'none';
+  });
+});
+
 document.getElementById('btn-ranking').addEventListener('click', () => {
   document.getElementById('filters-row').style.display = 'flex';
   document.getElementById('classificacio-filters').style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -66,16 +66,22 @@ h1 {
 
 #menu {
   display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
+  flex-direction: column;
   margin-bottom: 0.5rem;
 }
 
-#menu > button {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.menu-group > button {
+  width: 100%;
+}
+
+.submenu {
+  display: none;
+  margin-left: 0.5rem;
+  flex-direction: column;
+}
+
+.submenu button {
+  width: 100%;
 }
 
 button {


### PR DESCRIPTION
## Summary
- Crea un nivell superior de navegació amb submenús per agrupar seccions
- Reanomena botons de l'històric i reorganitza l'estructura del menú
- Oculta contingut i filtres en canviar entre seccions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689ef61c4b50832ea3f71dc4735eb9d9