### PR TITLE
Reorganitza el menú principal en graella 2x2 i ajusta colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,28 +15,23 @@
       <button id="btn-update" aria-label="Actualitza" title="Actualitza">🔄</button>
     </h1>
     <div id="menu">
-    <div class="menu-group">
       <button class="menu-toggle" data-target="submenu-billar">Secció Billar</button>
+      <button class="menu-toggle" data-target="submenu-campionats">Campionats en curs</button>
+      <button class="menu-toggle" data-target="submenu-historic">Històric</button>
+      <button class="menu-toggle" data-target="submenu-multimedia">Multimedia</button>
+    </div>
+    <div id="submenu-container">
       <div id="submenu-billar" class="submenu">
         <button id="btn-agenda">Agenda Billar</button>
         <button id="btn-horari">Normativa i Horari</button>
       </div>
-    </div>
-    <div class="menu-group">
-      <button class="menu-toggle" data-target="submenu-campionats">Campionats en curs</button>
       <div id="submenu-campionats" class="submenu">
         <button id="btn-torneig">Social en curs</button>
       </div>
-    </div>
-    <div class="menu-group">
-      <button class="menu-toggle" data-target="submenu-historic">Històric</button>
       <div id="submenu-historic" class="submenu">
         <button id="btn-ranking">Rànquings</button>
         <button id="btn-classificacio">Classificacions Socials</button>
       </div>
-    </div>
-    <div class="menu-group">
-      <button class="menu-toggle" data-target="submenu-multimedia">Multimedia</button>
       <div id="submenu-multimedia" class="submenu">
         <button id="btn-enllacos">Enllaços Billar</button>
       </div>
@@ -67,7 +62,6 @@
     </div>
     <div id="torneig-category-buttons" class="button-group category-buttons" style="display:none"></div>
     <!-- aquí es poden afegir més botons en el futur -->
-    </div>
     <div id="content"></div>
 
   </div>

--- a/style.css
+++ b/style.css
@@ -3,6 +3,8 @@
   --primary-dark: #004377;
   --secondary: #00695c;
   --secondary-dark: #004d43;
+  --tertiary: #9c27b0;
+  --tertiary-dark: #6d1b7b;
   --category: #8d4f00;
   --category-dark: #5a3300;
   --background: #f9f9f9;
@@ -65,23 +67,25 @@ h1 {
 }
 
 #menu {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
   margin-bottom: 0.5rem;
-}
-
-.menu-group > button {
-  width: 100%;
 }
 
 .submenu {
   display: none;
-  margin-left: 0.5rem;
   flex-direction: column;
+  margin-top: 0.5rem;
 }
 
 .submenu button {
   width: 100%;
+  background: var(--secondary);
+}
+
+.submenu button:hover {
+  background: var(--secondary-dark);
 }
 
 button {
@@ -125,12 +129,12 @@ button:active {
 }
 
 .secondary-buttons button {
-  background: var(--secondary);
+  background: var(--tertiary);
 }
 
 .secondary-buttons button:hover,
 .secondary-buttons button.selected {
-  background: var(--secondary-dark);
+  background: var(--tertiary-dark);
 }
 
 .category-buttons button {


### PR DESCRIPTION
## Summary
- Organitza els quatre botons principals en una graella 2x2 i mou els submenús per sota
- Afegeix una jerarquia de colors: nivell principal, submenús i botons secundaris
## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_689ef84d6f44832e9a345a8cb9d5e1ab