### PR TITLE
Arrange section buttons on a single row

### DIFF
--- a/style.css
+++ b/style.css
@@ -67,20 +67,24 @@ h1 {
 }
 
 #menu {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
 }
 
+#menu button {
+  flex: 1;
+}
+
 .submenu {
   display: none;
-  flex-direction: column;
+  flex-wrap: wrap;
   margin-top: 0.5rem;
 }
 
 .submenu button {
-  width: 100%;
+  flex: 1;
   background: var(--secondary);
 }
 


### PR DESCRIPTION
## Summary
- use flex layout for the main menu so buttons appear on one row when space permits
- allow submenu buttons to share a row using flex and flexible widths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689efe1e7fe8832e9f70d5a11dd6d5e2