### PR TITLE
Add Rànquing Continu 3B section with API client

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_APPS_SCRIPT_URL=https://script.google.com/macros/s/AKfycbw4pBmXRKV7R9H0-KGWXyECzjU9tR5VEy3rIN8h-ydIKB3lnOkk_BExO4G8OHGJCR-0/exec
+VITE_API_TOKEN=abcd12345

--- a/api.js
+++ b/api.js
@@ -1,0 +1,68 @@
+// api.js — client per la PWA del Torneig Continu 3B
+// Usa les rutes tc3b/* i envia el token automàticament
+
+const API_BASE = import.meta.env.VITE_APPS_SCRIPT_URL; // ex. "https://script.google.com/macros/s/XXXX/exec"
+const API_TOKEN = import.meta.env.VITE_API_TOKEN;      // ex. "abcd1234"
+
+async function apiRequest(path, method = 'GET', body = null) {
+  const url = `${API_BASE}?path=${encodeURIComponent(path)}`;
+  const opts = {
+    method,
+    headers: { 'Content-Type': 'application/json' }
+  };
+  if (body) {
+    // sempre incloem el token a POST
+    opts.body = JSON.stringify({ token: API_TOKEN, ...body });
+  }
+  return fetch(url, opts).then(r => r.json());
+}
+
+// ----------- ENDPOINTS NOUS tc3b/* -----------
+
+export function apiGetClassificacio() {
+  return apiRequest('tc3b/classificacio', 'GET');
+}
+
+export function apiGetEspera() {
+  return apiRequest('tc3b/espera', 'GET');
+}
+
+export function apiPostEsperaAlta(jugador_id) {
+  return apiRequest('tc3b/espera', 'POST', { accio: 'alta', jugador_id });
+}
+
+export function apiPostEsperaBaixa(jugador_id) {
+  return apiRequest('tc3b/espera', 'POST', { accio: 'baixa', jugador_id });
+}
+
+export function apiGetReptes() {
+  return apiRequest('tc3b/reptes', 'GET');
+}
+
+export function apiCreateRepteNormal(reptador_id, reptat_id, dates_proposta = []) {
+  return apiRequest('tc3b/reptes', 'POST', { tipus: 'normal', reptador_id, reptat_id, dates_proposta });
+}
+
+export function apiCreateRepteAcces(reptador_id, reptat_id) {
+  return apiRequest('tc3b/reptes', 'POST', { tipus: 'acces', reptador_id, reptat_id });
+}
+
+export function apiAcceptRepte(id) {
+  return apiRequest(`tc3b/reptes/${id}?action=acceptar`, 'POST', {});
+}
+
+export function apiResultatRepte(id, guanya_reptador, motiu = 'RESULTAT', partida = {}) {
+  return apiRequest(`tc3b/reptes/${id}?action=resultat`, 'POST', { guanya_reptador, motiu, partida });
+}
+
+export function apiSenseAcordRepte(id) {
+  return apiRequest(`tc3b/reptes/${id}?action=sense-acord`, 'POST', {});
+}
+
+export function apiIncompareixencaRepte(id) {
+  return apiRequest(`tc3b/reptes/${id}?action=incompareixenca`, 'POST', {});
+}
+
+export function apiRevisioInactivitat() {
+  return apiRequest('tc3b/cron/revisio-inactivitat', 'POST', {});
+}

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       </div>
       <div id="submenu-campionats" class="submenu">
         <button id="btn-torneig">Social en curs</button>
+        <button id="btn-tc3b">Rànquing Continu 3B</button>
       </div>
       <div id="submenu-historic" class="submenu">
         <button id="btn-ranking">Rànquings</button>
@@ -79,7 +80,7 @@
       <canvas id="chart-canvas"></canvas>
     </div>
   </div>
-  <script src="main.js"></script>
+  <script type="module" src="main.js"></script>
 
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,3 +1,5 @@
+import { apiGetClassificacio } from "./api.js";
+
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('./service-worker.js')
@@ -1408,6 +1410,30 @@ document.getElementById('btn-torneig').addEventListener('click', () => {
       title.style.display = 'none';
     });
 });
+
+document.getElementById('btn-tc3b').addEventListener('click', () => {
+  document.getElementById('filters-row').style.display = 'none';
+  document.getElementById('classificacio-filters').style.display = 'none';
+  document.getElementById('torneig-buttons').style.display = 'none';
+  document.getElementById('torneig-title').style.display = 'none';
+  document.getElementById('torneig-category-buttons').style.display = 'none';
+  const cont = document.getElementById('content');
+  cont.style.display = 'block';
+  cont.textContent = 'Carregant...';
+  apiGetClassificacio()
+    .then(data => {
+      const pre = document.createElement('pre');
+      pre.textContent = JSON.stringify(data, null, 2);
+      cont.innerHTML = '';
+      cont.appendChild(pre);
+    })
+    .catch(err => {
+      cont.innerHTML = '<p>Error carregant dades.</p>';
+      console.error('Error API TC3B', err);
+    });
+});
+
+
 
 document.querySelectorAll('#torneig-buttons button').forEach(btn => {
   btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Add API client for TC3B Google Sheet endpoints and environment variables
- Extend Campionats menu with new "Rànquing Continu 3B" section using the API

## Testing
- `node --check main.js && echo "main.js syntax ok"`
- `node --check api.js && echo "api.js syntax ok"`
- `python3 -m py_compile server.py && echo "server.py syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_689f3bdb8ffc832ea95bbd4605e0f08c