### PR TITLE
Fix Mitjana column lookup in update_classificacions

### DIFF
--- a/tools/update_classificacions.py
+++ b/tools/update_classificacions.py
@@ -76,13 +76,13 @@ def normalise_rows(rows: List[dict[str, str]]) -> List[dict[str, str]]:
     """Ensure required fields and normalise ``Mitjana*`` to dot decimals."""
     out: List[dict[str, str]] = []
     for row in rows:
-        mitjana_general = str(row.get("MitjanaGeneral", "")).replace(",", ".")
+        mitjana_general = str(row.get("Mitjana General", "")).replace(",", ".")
         if mitjana_general:
             try:
                 mitjana_general = str(float(mitjana_general))
             except ValueError:
                 pass
-        mitjana_particular = str(row.get("MitjanaParticular", "")).replace(",", ".")
+        mitjana_particular = str(row.get("Mitjana Particular", "")).replace(",", ".")
         if mitjana_particular:
             try:
                 mitjana_particular = str(float(mitjana_particular))


### PR DESCRIPTION
## Summary
- read Mitjana columns using headers with spaces when syncing classificacions

## Testing
- `python -m py_compile tools/update_classificacions.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3b06b318832eb851e8fe67e05aec