### PR TITLE
Handle missing env to restore menu buttons

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,8 +1,14 @@
 // api.js — client per la PWA del Torneig Continu 3B
 // Usa les rutes tc3b/* i envia el token automàticament
 
-const API_BASE = import.meta.env.VITE_APPS_SCRIPT_URL; // ex. "https://script.google.com/macros/s/XXXX/exec"
-const API_TOKEN = import.meta.env.VITE_API_TOKEN;      // ex. "abcd1234"
+// "import.meta.env" només existeix quan l'app s'empra amb un bundler com Vite.
+// En executar el codi directament al navegador, "import.meta.env" és undefined
+// i intentant accedir-hi provocava un error que aturava tota la inicialització
+// de la PWA.  Fem servir valors buits per defecte quan les variables no hi són,
+// de manera que la resta de funcionalitats (rànquing, agenda, etc.) continuïn
+// funcionant encara que les crides a l'API del torneig no estiguin configurades.
+const API_BASE = (import.meta.env && import.meta.env.VITE_APPS_SCRIPT_URL) || '';
+const API_TOKEN = (import.meta.env && import.meta.env.VITE_API_TOKEN) || '';
 
 async function apiRequest(path, method = 'GET', body = null) {
   const url = `${API_BASE}?path=${encodeURIComponent(path)}`;


### PR DESCRIPTION
## Summary
- Avoid crash when `import.meta.env` is undefined in browsers by providing safe defaults for API configuration
- Add clarifying comments about missing env values and maintain functionality even without configured API

## Testing
- `node -e "import('./api.js').then(()=>console.log('api ok')).catch(err=>console.error(err))"`

------
https://chatgpt.com/codex/tasks/task_e_689f40bcaea0832e8856f5b9d3525541