### PR TITLE
feat: add Ordre page

### DIFF
--- a/components/OrdreTable.jsx
+++ b/components/OrdreTable.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export default function OrdreTable({ data, loading }) {
+  return (
+    <table className="ordre-table">
+      <thead>
+        <tr>
+          <th>Posició</th>
+          <th>Jugador</th>
+        </tr>
+      </thead>
+      <tbody>
+        {loading ? (
+          <tr>
+            <td colSpan="2" className="ordre-loading-cell">
+              <div className="spinner" />
+            </td>
+          </tr>
+        ) : data.length === 0 ? (
+          <tr>
+            <td colSpan="2" className="ordre-empty">No hi ha dades d’ordre</td>
+          </tr>
+        ) : (
+          data.map((item) => (
+            <tr key={item.jugador_id}>
+              <td>{item.posicio}</td>
+              <td>{item.jugador_id}</td>
+            </tr>
+          ))
+        )}
+      </tbody>
+    </table>
+  );
+}

--- a/components/OrdreToolbar.jsx
+++ b/components/OrdreToolbar.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function OrdreToolbar({ onRefresh, secondsAgo }) {
+  return (
+    <div className="ordre-toolbar">
+      <h3>Ordre</h3>
+      <div className="ordre-toolbar-actions">
+        <button onClick={onRefresh}>Actualitza</button>
+        <span className="ordre-toolbar-time">
+          {secondsAgo !== null ? `Actualitzat fa ${secondsAgo}s` : ''}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/main.js
+++ b/main.js
@@ -1,5 +1,3 @@
-import { apiGetClassificacio } from "./api.js";
-
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('./service-worker.js')
@@ -1412,6 +1410,11 @@ document.getElementById('btn-torneig').addEventListener('click', () => {
 });
 
 document.getElementById('btn-tc3b').addEventListener('click', () => {
+  history.pushState({}, '', '/ordre');
+  mostraOrdre();
+});
+
+function mostraOrdre() {
   document.getElementById('filters-row').style.display = 'none';
   document.getElementById('classificacio-filters').style.display = 'none';
   document.getElementById('torneig-buttons').style.display = 'none';
@@ -1419,18 +1422,26 @@ document.getElementById('btn-tc3b').addEventListener('click', () => {
   document.getElementById('torneig-category-buttons').style.display = 'none';
   const cont = document.getElementById('content');
   cont.style.display = 'block';
-  cont.textContent = 'Carregant...';
-  apiGetClassificacio()
-    .then(data => {
-      const pre = document.createElement('pre');
-      pre.textContent = JSON.stringify(data, null, 2);
-      cont.innerHTML = '';
-      cont.appendChild(pre);
+  cont.innerHTML = '';
+  Promise.all([
+    import('./pages/Ordre.jsx'),
+    import('react'),
+    import('react-dom/client')
+  ])
+    .then(([mod, React, ReactDOM]) => {
+      const root = ReactDOM.createRoot(cont);
+      root.render(React.createElement(mod.default));
     })
     .catch(err => {
       cont.innerHTML = '<p>Error carregant dades.</p>';
-      console.error('Error API TC3B', err);
+      console.error('Error carregant Ordre', err);
     });
+}
+
+window.addEventListener('popstate', () => {
+  if (location.pathname === '/ordre') {
+    mostraOrdre();
+  }
 });
 
 
@@ -1471,3 +1482,6 @@ window.addEventListener('resize', () => {
 });
 
 inicialitza();
+if (location.pathname === '/ordre') {
+  mostraOrdre();
+}

--- a/pages/Ordre.jsx
+++ b/pages/Ordre.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { apiGetClassificacio } from '../api.js';
+import OrdreTable from '../components/OrdreTable.jsx';
+import OrdreToolbar from '../components/OrdreToolbar.jsx';
+
+export default function Ordre() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [updatedAt, setUpdatedAt] = useState(null);
+  const [now, setNow] = useState(Date.now());
+
+  const fetchData = () => {
+    setLoading(true);
+    setError(null);
+    apiGetClassificacio()
+      .then(json => {
+        if (json.error) {
+          throw new Error(json.error);
+        }
+        const items = Array.isArray(json.items) ? json.items : [];
+        const ordered = items.sort((a, b) => a.posicio - b.posicio);
+        setData(ordered);
+        setUpdatedAt(Date.now());
+      })
+      .catch(() => setError('Error carregant dades.'))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const secondsAgo = updatedAt ? Math.floor((now - updatedAt) / 1000) : null;
+
+  return (
+    <div>
+      {error && <div className="ordre-error">{error}</div>}
+      <OrdreToolbar onRefresh={fetchData} secondsAgo={secondsAgo} />
+      <OrdreTable data={data} loading={loading} />
+    </div>
+  );
+}
+
+/*
+Tests manuals:
+- Mock { items:[{posicio:1,jugador_id:'J001'}] } → es renderitza una fila.
+- Si l’API falla → es veu un banner d’error.
+- En clicar Actualitza → re-fetch i actualitza el “fa Xs”.
+*/

--- a/service-worker.js
+++ b/service-worker.js
@@ -25,6 +25,9 @@ self.addEventListener('activate', (event) => {
 workbox.precaching.precacheAndRoute([
   { url: './style.css', revision: CACHE_VERSION },
   { url: './main.js', revision: CACHE_VERSION },
+  { url: './pages/Ordre.jsx', revision: CACHE_VERSION },
+  { url: './components/OrdreTable.jsx', revision: CACHE_VERSION },
+  { url: './components/OrdreToolbar.jsx', revision: CACHE_VERSION },
   { url: 'https://cdn.jsdelivr.net/npm/chart.js', revision: null },
   { url: './data/ranquing.json', revision: CACHE_VERSION },
   { url: './classificacions.json', revision: CACHE_VERSION },

--- a/style.css
+++ b/style.css
@@ -588,3 +588,61 @@ details summary {
 }
 
 
+/* Ordre page */
+.ordre-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.ordre-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.ordre-toolbar-time {
+  font-size: 0.9rem;
+  color: #555;
+}
+.ordre-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.ordre-table th, .ordre-table td {
+  padding: 0.4rem;
+  text-align: left;
+}
+.ordre-table thead th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+}
+.ordre-table tbody tr:nth-child(odd) {
+  background: #f8f8f8;
+}
+.ordre-error {
+  background: #fdd;
+  color: #900;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  border-radius: 4px;
+}
+.spinner {
+  width: 24px;
+  height: 24px;
+  border: 4px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+.ordre-loading-cell {
+  text-align: center;
+}
+.ordre-empty {
+  text-align: center;
+  padding: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add Ordre page with toolbar and table
- wire route /ordre loading the new React components
- style Ordre table and precache new modules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f434d9df4832e8b0547cc39c9838e