### PR TITLE
Handle missing API configuration gracefully

### DIFF
--- a/api.js
+++ b/api.js
@@ -11,6 +11,9 @@ const API_BASE = (import.meta.env && import.meta.env.VITE_APPS_SCRIPT_URL) || ''
 const API_TOKEN = (import.meta.env && import.meta.env.VITE_API_TOKEN) || '';
 
 async function apiRequest(path, method = 'GET', body = null) {
+  if (!API_BASE) {
+    return { error: 'API no configurada' };
+  }
   const url = `${API_BASE}?path=${encodeURIComponent(path)}`;
   const opts = {
     method,

--- a/pages/Ordre.jsx
+++ b/pages/Ordre.jsx
@@ -16,7 +16,8 @@ export default function Ordre() {
     apiGetClassificacio()
       .then(json => {
         if (json.error) {
-          throw new Error(json.error);
+          setError(json.error);
+          return;
         }
         const items = Array.isArray(json.items) ? json.items : [];
         const ordered = items.sort((a, b) => a.posicio - b.posicio);


### PR DESCRIPTION
## Summary
- Prevent API requests when no base URL is configured by returning an explicit error
- Surface API configuration errors on the Ordre page without triggering fetch

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check api.js pages/Ordre.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689f4b14a178832ebbf58b70bd291bae