### PR TITLE
Handle missing API base URL gracefully

### DIFF
--- a/api.js
+++ b/api.js
@@ -11,6 +11,9 @@ const API_BASE = (import.meta.env && import.meta.env.VITE_APPS_SCRIPT_URL) || ''
 const API_TOKEN = (import.meta.env && import.meta.env.VITE_API_TOKEN) || '';
 
 async function apiRequest(path, method = 'GET', body = null) {
+  if (!API_BASE) {
+    return Promise.resolve({ error: 'API no configurada' });
+  }
   const url = `${API_BASE}?path=${encodeURIComponent(path)}`;
   const opts = {
     method,

--- a/pages/Ordre.jsx
+++ b/pages/Ordre.jsx
@@ -16,7 +16,9 @@ export default function Ordre() {
     apiGetClassificacio()
       .then(json => {
         if (json.error) {
-          throw new Error(json.error);
+          setError(json.error);
+          setData([]);
+          return;
         }
         const items = Array.isArray(json.items) ? json.items : [];
         const ordered = items.sort((a, b) => a.posicio - b.posicio);


### PR DESCRIPTION
## Summary
- Return a clear `{ error: 'API no configurada' }` when `API_BASE` is unset
- Surface API errors on the Ordre page without throwing
- Always resolve a promise from `apiRequest` so callers can safely `.then`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check api.js`


------
https://chatgpt.com/codex/tasks/task_e_689f4a0c17e4832e936081b4b8aab299