### PR TITLE
Afegeix secció Continu 3B als campionats en curs

### DIFF
--- a/data/continu3b.json
+++ b/data/continu3b.json
@@ -1,0 +1,4 @@
+[
+  { "Pos": 1, "Jugador": "Jugador A", "Punts": 10 },
+  { "Pos": 2, "Jugador": "Jugador B", "Punts": 8 }
+]

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       </div>
       <div id="submenu-campionats" class="submenu">
         <button id="btn-torneig">Social en curs</button>
+        <button id="btn-continu3b">Continu 3B</button>
       </div>
       <div id="submenu-historic" class="submenu">
         <button id="btn-ranking">Rànquings</button>

--- a/main.js
+++ b/main.js
@@ -687,6 +687,38 @@ function mostraEnllacos() {
 }
 
 
+
+function mostraContinu3B(dades) {
+  const cont = document.getElementById('content');
+  cont.innerHTML = '';
+  if (!Array.isArray(dades) || dades.length === 0) {
+    cont.innerHTML = '<p>No hi ha dades disponibles.</p>';
+    return;
+  }
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  Object.keys(dades[0]).forEach(k => {
+    const th = document.createElement('th');
+    th.textContent = k;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+  const tbody = document.createElement('tbody');
+  dades.forEach(row => {
+    const tr = document.createElement('tr');
+    Object.values(row).forEach(val => {
+      const td = document.createElement('td');
+      td.textContent = val;
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  appendResponsiveTable(cont, table);
+}
+
 function mostraEvolucioJugador(jugador, nom) {
   const modalitats = ['3 BANDES', 'BANDA', 'LLIURE'];
   const dadesPerMod = modalitats.map(mod =>
@@ -1373,6 +1405,23 @@ document.getElementById('btn-enllacos').addEventListener('click', () => {
   document.getElementById('torneig-category-buttons').style.display = 'none';
   document.getElementById('content').style.display = 'block';
   mostraEnllacos();
+});
+
+document.getElementById('btn-continu3b').addEventListener('click', () => {
+  document.getElementById('filters-row').style.display = 'none';
+  document.getElementById('classificacio-filters').style.display = 'none';
+  document.getElementById('torneig-buttons').style.display = 'none';
+  document.getElementById('torneig-title').style.display = 'none';
+  document.getElementById('torneig-category-buttons').style.display = 'none';
+  const cont = document.getElementById('content');
+  cont.style.display = 'block';
+  fetch('data/continu3b.json')
+    .then(r => r.json())
+    .then(d => mostraContinu3B(d))
+    .catch(err => {
+      console.error('Error carregant continu 3B', err);
+      cont.innerHTML = '<p>Error carregant dades.</p>';
+    });
 });
 
 document.getElementById('btn-torneig').addEventListener('click', () => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.3/workbox-sw.js');
 
 // This value is replaced at build time by tools/update_sw_version.py
-const CACHE_VERSION = '20250815151530';
+const CACHE_VERSION = '20250815180044';
 
 self.addEventListener('install', () => self.skipWaiting());
 
@@ -29,6 +29,7 @@ workbox.precaching.precacheAndRoute([
   { url: './data/ranquing.json', revision: CACHE_VERSION },
   { url: './classificacions.json', revision: CACHE_VERSION },
   { url: './data/events.json', revision: CACHE_VERSION },
+  { url: './data/continu3b.json', revision: CACHE_VERSION },
   { url: './icons/icon-192.png', revision: CACHE_VERSION },
   { url: './icons/icon-512.png', revision: CACHE_VERSION }
 ]);


### PR DESCRIPTION
## Resum
- Afegeix el botó "Continu 3B" al submenú de Campionats en curs
- Mostra un tauler amb dades de Continu 3B i n'encarrega les dades corresponents
- Inclou el nou fitxer en la memòria cau del service worker

## Proves
- `npm test` (falla: Could not read package.json)
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f74d5ab10832ea27de432926a75d8