### PR TITLE
Add workflow to sync Continu3B sheet

### DIFF
--- a/.github/workflows/update-continu3B.yml
+++ b/.github/workflows/update-continu3B.yml
@@ -1,0 +1,27 @@
+# yamllint disable rule:truthy
+---
+name: Sync Continu3B Sheet (API)
+
+on:
+  workflow_dispatch: {}  # yamllint disable-line truthy
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      CONTINU_ID: ${{ secrets.CONTINU_ID }}
+      OUTPUT_DIR: data
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: pip install --upgrade google-api-python-client google-auth
+      - name: Run sync
+        run: python3 tools/update_continu3B.py
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update Continu3B from Google Sheets API'

--- a/tools/update_continu3B.py
+++ b/tools/update_continu3B.py
@@ -34,7 +34,7 @@ MITJANA_RE = re.compile(r"^\d+(\.\d+)?$")
 TABS = [
     "Paràmetres",
     "Jugadors",
-    "RanquingActiu",
+    "RankingActiu",
     "Reptes",
     "LlistaEspera",
     "Partides",


### PR DESCRIPTION
## Summary
- add scheduled workflow to fetch Continu3B sheet tabs via `update_continu3B.py`
- correct Continu3B ranking tab name to `RankingActiu`

## Testing
- `python -m py_compile tools/update_continu3B.py`
- `yamllint .github/workflows/update-continu3B.yml`


------
https://chatgpt.com/codex/tasks/task_e_689f97a3ff08832ebd67a16d3d64b5eb