### PR TITLE
Add Continu 3B normative button with rules

### DIFF
--- a/main.js
+++ b/main.js
@@ -947,7 +947,91 @@ function mostraContinu3B() {
         })
       );
 
-      [btnRanking, btnReptes, btnLlista, btnAcces].forEach(b =>
+      const btnNormativa = document.createElement('button');
+      btnNormativa.textContent = 'Normativa';
+      btnNormativa.addEventListener('click', () =>
+        showSection(btnNormativa, () => {
+          const title = document.createElement('h3');
+          title.textContent = 'Normativa';
+          cont.appendChild(title);
+
+          const list = document.createElement('ul');
+
+          const liRanking = document.createElement('li');
+          liRanking.textContent =
+            'Rànquing actiu: màxim 20 jugadors, actualitzat contínuament mitjançant reptes directes.';
+          list.appendChild(liRanking);
+
+          const liReptes = document.createElement('li');
+          liReptes.textContent =
+            'Reptes normals: pots reptar fins a 2 posicions per sobre teu, màxim un repte actiu per jugador, mínim 7 dies entre reptes.';
+          const subReptes = document.createElement('ul');
+          const liReptesGuanya = document.createElement('li');
+          liReptesGuanya.textContent = 'Si guanya el reptador → intercanvi de posicions.';
+          subReptes.appendChild(liReptesGuanya);
+          const liReptesPerd = document.createElement('li');
+          liReptesPerd.textContent = 'Si perd → no hi ha canvis.';
+          subReptes.appendChild(liReptesPerd);
+          liReptes.appendChild(subReptes);
+          list.appendChild(liReptes);
+
+          const liAcces = document.createElement('li');
+          liAcces.textContent =
+            'Reptes d’accés: primer de la llista d’espera pot reptar el jugador 20.';
+          const subAcces = document.createElement('ul');
+          const liAccesGuanya = document.createElement('li');
+          liAccesGuanya.textContent =
+            'Si guanya → entra al rànquing (pos. 20) i el perdedor passa a la llista d’espera.';
+          subAcces.appendChild(liAccesGuanya);
+          const liAccesPerd = document.createElement('li');
+          liAccesPerd.textContent = 'Si perd → passa al final de la llista d’espera.';
+          subAcces.appendChild(liAccesPerd);
+          liAcces.appendChild(subAcces);
+          list.appendChild(liAcces);
+
+          const liTerminis = document.createElement('li');
+          liTerminis.textContent =
+            'Terminis: 7 dies per acceptar un repte i 7 dies per jugar-lo un cop acceptat.';
+          list.appendChild(liTerminis);
+
+          const liPen = document.createElement('li');
+          liPen.textContent = 'Penalitzacions:';
+          const subPen = document.createElement('ul');
+          const liPen1 = document.createElement('li');
+          liPen1.textContent =
+            'Incompareixença o refús sense motiu → derrota automàtica.';
+          subPen.appendChild(liPen1);
+          const liPen2 = document.createElement('li');
+          liPen2.textContent =
+            'Sense acord de data → tots dos perden una posició.';
+          subPen.appendChild(liPen2);
+          liPen.appendChild(subPen);
+          list.appendChild(liPen);
+
+          const liInact = document.createElement('li');
+          liInact.textContent = 'Inactivitat:';
+          const subInact = document.createElement('ul');
+          const liInact1 = document.createElement('li');
+          liInact1.textContent =
+            '3 setmanes sense reptes → baixa 5 posicions (pre-inactiu).';
+          subInact.appendChild(liInact1);
+          const liInact2 = document.createElement('li');
+          liInact2.textContent =
+            '6 setmanes sense reptes → surt del rànquing i entra el primer de la llista d’espera.';
+          subInact.appendChild(liInact2);
+          liInact.appendChild(subInact);
+          list.appendChild(liInact);
+
+          cont.appendChild(list);
+
+          const link = document.createElement('p');
+          link.innerHTML =
+            'Consulta la <a href="https://docs.google.com/document/d/165_bh9m0WxRU_LoTt_k8aiJseZZn9bBZ/edit?usp=sharing&amp;ouid=102336298592739127647&amp;rtpof=true&amp;sd=true" target="_blank" rel="noopener">normativa completa</a>.';
+          cont.appendChild(link);
+        })
+      );
+
+      [btnRanking, btnReptes, btnLlista, btnAcces, btnNormativa].forEach(b =>
         btnContainer.appendChild(b)
       );
 


### PR DESCRIPTION
## Summary
- Add `Normativa` button to Continu 3B section displaying ranking rules and penalties
- Include link to the complete rules document

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0434588c4832e94589111b5a8795b