### PR TITLE
Afegir nota de llista d'espera al rànquing Continu3B

### DIFF
--- a/js/continu3b.js
+++ b/js/continu3b.js
@@ -359,7 +359,7 @@ export function mostraContinu3B() {
 
   <div class="normes-card">
     <h3>Rànquing actiu</h3>
-    <p>Màxim 20 jugadors, actualitzat contínuament mitjançant reptes directes.</p>
+    <p>Màxim 20 jugadors, actualitzat contínuament mitjançant reptes directes. Els jugadors que vulguin formar part del rànquing un cop s'arribi al màxim de 20 jugadors formaran part de la llista d'espera.</p>
   </div>
 
   <div class="normes-card">


### PR DESCRIPTION
## Summary
- Afegeix una nota a la targeta "Rànquing actiu" de la normativa Continu 3B indicant que, quan s'arriba al màxim de 20 jugadors, els nous interessats entren en llista d'espera.

## Testing
- `npm test` *(falla: no s'ha trobat package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a053e120b8832eb6f540d7bf56c2a7