### PR TITLE
Add challenge cooldown logic to Continu 3B ranking

### DIFF
--- a/js/continu3b.js
+++ b/js/continu3b.js
@@ -13,19 +13,48 @@ export function mostraContinu3B() {
     fetch('data/continu3b_llistaespera.json').then(r => r.json()).catch(() => []),
     fetch('data/continu3b_reptes.json').then(r => r.json()).catch(() => []),
     fetch('data/continu3b_partides.json').then(r => r.json()).catch(() => []),
-    fetch('data/continu3b_jugadors.json').then(r => r.json()).catch(() => [])
+    fetch('data/continu3b_jugadors.json').then(r => r.json()).catch(() => []),
+    fetch('data/continu3b_parametres.json').then(r => r.json()).catch(() => [])
   ])
-    .then(([ranking, llista, reptes, partides, jugadors]) => {
+    .then(([ranking, llista, reptes, partides, jugadors, parametres]) => {
 
       const mapJugadors = Object.fromEntries(jugadors.map(j => [j.id, j.nom]));
 
-      const esReptable = dataStr => {
+      const cooldownReptar =
+        parseInt(
+          (parametres.find(p => p.clau === 'COOLDOWN_REPTAR_DIES') || {})
+            .valor,
+          10
+        ) || 7;
+
+      const potReptar = (id, dataStr) => {
+        const actiu = reptes.some(
+          r =>
+            r.reptador_id === id &&
+            ['proposat', 'acceptat', 'programat'].includes(r.estat)
+        );
+        if (actiu) return false;
         if (!dataStr) return true;
         const [d, m, y] = dataStr.split('/');
         const parsed = new Date(`${y}-${m}-${d}T00:00:00`);
         if (isNaN(parsed)) return true;
         const diff = (Date.now() - parsed.getTime()) / (1000 * 60 * 60 * 24);
-        return diff >= 7;
+        return diff >= cooldownReptar;
+      };
+
+      const potSerReptat = (id, dataStr) => {
+        const actiu = reptes.some(
+          r =>
+            r.reptat_id === id &&
+            ['proposat', 'acceptat', 'programat'].includes(r.estat)
+        );
+        if (actiu) return false;
+        if (!dataStr) return true;
+        const [d, m, y] = dataStr.split('/');
+        const parsed = new Date(`${y}-${m}-${d}T00:00:00`);
+        if (isNaN(parsed)) return true;
+        const diff = (Date.now() - parsed.getTime()) / (1000 * 60 * 60 * 24);
+        return diff >= cooldownReptar;
       };
 
       function mostraPartidesJugador(id, nom) {
@@ -102,7 +131,7 @@ export function mostraContinu3B() {
             const table = document.createElement('table');
             const thead = document.createElement('thead');
             const headerRow = document.createElement('tr');
-            ['Posició', 'Jugador', ''].forEach(h => {
+            ['Posició', 'Jugador', 'Reptar', 'Ser reptat'].forEach(h => {
               const th = document.createElement('th');
               th.textContent = h;
               headerRow.appendChild(th);
@@ -127,14 +156,29 @@ export function mostraContinu3B() {
                 );
                 nameTd.appendChild(nameBtn);
                 tr.appendChild(nameTd);
-                const reptTd = document.createElement('td');
                 const info = jugadors.find(j => j.id === r.jugador_id);
-                const reptable = esReptable(info ? info.data_ultim_repte : '');
-                const span = document.createElement('span');
-                span.textContent = reptable ? '🟢' : '🔴';
-                span.title = reptable ? 'Reptable' : 'No reptable';
-                reptTd.appendChild(span);
-                tr.appendChild(reptTd);
+                const potRep = potReptar(
+                  r.jugador_id,
+                  info ? info.data_ultim_repte : ''
+                );
+                const potReptarTd = document.createElement('td');
+                const potReptarSpan = document.createElement('span');
+                potReptarSpan.textContent = potRep ? '🔵' : '⚪';
+                potReptarSpan.title = potRep ? 'Pot reptar' : 'No pot reptar';
+                potReptarTd.appendChild(potReptarSpan);
+                tr.appendChild(potReptarTd);
+                const potSer = potSerReptat(
+                  r.jugador_id,
+                  info ? info.data_ultim_repte : ''
+                );
+                const potSerTd = document.createElement('td');
+                const potSerSpan = document.createElement('span');
+                potSerSpan.textContent = potSer ? '🟢' : '🔴';
+                potSerSpan.title = potSer
+                  ? 'Pot ser reptat'
+                  : 'No pot ser reptat';
+                potSerTd.appendChild(potSerSpan);
+                tr.appendChild(potSerTd);
                 tbody.appendChild(tr);
               });
             table.appendChild(tbody);


### PR DESCRIPTION
## Summary
- Prevent players from challenging if they already have an active challenge or are still within the cooldown period
- Load `COOLDOWN_REPTAR_DIES` parameter from sheet data for flexible cooldown configuration
- Block players from being challenged when they have an active challenge or are within the same cooldown window
- Display colored indicators in the ranking for who can challenge, can be challenged, or cannot be challenged

## Testing
- `node --check js/continu3b.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a089162ef4832e9819cc79f8c93a7d