### PR TITLE
Afegir filtre de disponibles al rànquing 3B

### DIFF
--- a/js/continu3b.js
+++ b/js/continu3b.js
@@ -109,8 +109,19 @@ export function mostraContinu3B() {
         render();
       };
 
+      const filterLabel = document.createElement('label');
+      filterLabel.id = 'ranking-filter-disponibles';
+      const chkDisponibles = document.createElement('input');
+      chkDisponibles.type = 'checkbox';
+      filterLabel.appendChild(chkDisponibles);
+      filterLabel.appendChild(
+        document.createTextNode(' Mostra només disponibles')
+      );
+      btnContainer.appendChild(filterLabel);
+
       const btnRanking = document.createElement('button');
       btnRanking.textContent = 'Rànquing actual';
+      chkDisponibles.addEventListener('change', () => btnRanking.click());
       btnRanking.addEventListener('click', () =>
         showSection(btnRanking, () => {
           const title = document.createElement('h3');
@@ -141,10 +152,23 @@ export function mostraContinu3B() {
             thead.appendChild(headerRow);
             table.appendChild(thead);
             const tbody = document.createElement('tbody');
-            ranking
+            const ordered = ranking
               .slice()
-              .sort((a, b) => parseInt(a.posicio, 10) - parseInt(b.posicio, 10))
-              .forEach(r => {
+              .sort(
+                (a, b) =>
+                  parseInt(a.posicio, 10) - parseInt(b.posicio, 10)
+              );
+            const filtered = chkDisponibles.checked
+              ? ordered.filter(r => {
+                  const info = jugadors.find(j => j.id === r.jugador_id);
+                  return disponible(
+                    r.jugador_id,
+                    info ? info.data_ultim_repte : '',
+                    r.posicio
+                  );
+                })
+              : ordered;
+            filtered.forEach(r => {
                 const tr = document.createElement('tr');
                 const posTd = document.createElement('td');
                 posTd.textContent = r.posicio;

--- a/style.css
+++ b/style.css
@@ -587,4 +587,11 @@ details summary {
   color: #000;
 }
 
+#ranking-filter-disponibles {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 0.25rem;
+}
+
 


### PR DESCRIPTION
## Resum
- Incorpora un checkbox "Mostra només disponibles" al mòdul Continu 3B.
- Filtra el rànquing amb la funció `disponible` quan el control està activat.
- Afegeix estil bàsic per al nou filtre.

## Proves
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a10a07e0832e91afe855fc46f4ce