### PR TITLE
Highlight top three ranking rows

### DIFF
--- a/js/continu3b.js
+++ b/js/continu3b.js
@@ -129,6 +129,7 @@ export function mostraContinu3B() {
 
             cont.appendChild(legenda);
             const table = document.createElement('table');
+            table.classList.add('ranking-table');
             const thead = document.createElement('thead');
             const headerRow = document.createElement('tr');
 
@@ -144,8 +145,9 @@ export function mostraContinu3B() {
             ranking
               .slice()
               .sort((a, b) => parseInt(a.posicio, 10) - parseInt(b.posicio, 10))
-              .forEach(r => {
+              .forEach((r, idx) => {
                 const tr = document.createElement('tr');
+                if (idx < 3) tr.classList.add(`top${idx + 1}`);
                 const posTd = document.createElement('td');
                 posTd.textContent = r.posicio;
                 tr.appendChild(posTd);

--- a/style.css
+++ b/style.css
@@ -340,6 +340,21 @@ table:not(.agenda-table) tr:nth-child(even) {
   background: #f5f5f5;
 }
 
+.ranking-table .top1 {
+  background: #ffd700;
+  font-weight: bold;
+}
+
+.ranking-table .top2 {
+  background: #c0c0c0;
+  font-weight: bold;
+}
+
+.ranking-table .top3 {
+  background: #cd7f32;
+  font-weight: bold;
+}
+
 
 
 #chart-overlay {


### PR DESCRIPTION
## Summary
- Tag the first three ranking rows with `top1`, `top2`, `top3` classes and wrap ranking table with `ranking-table` class.
- Style top ranking rows with gold, silver, and bronze backgrounds.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a1108dd0832ea4ff8ee8e131ff87