### PR TITLE
Refactor ranking view to use card layout

### DIFF
--- a/js/continu3b.js
+++ b/js/continu3b.js
@@ -128,36 +128,24 @@ export function mostraContinu3B() {
               );
 
             cont.appendChild(legenda);
-            const table = document.createElement('table');
-            const thead = document.createElement('thead');
-            const headerRow = document.createElement('tr');
-
-            ['Posició', 'Jugador', 'Disponible'].forEach(h => {
-
-              const th = document.createElement('th');
-              th.textContent = h;
-              headerRow.appendChild(th);
-            });
-            thead.appendChild(headerRow);
-            table.appendChild(thead);
-            const tbody = document.createElement('tbody');
+            const cards = document.createElement('div');
+            cards.className = 'ranking-cards';
             ranking
               .slice()
               .sort((a, b) => parseInt(a.posicio, 10) - parseInt(b.posicio, 10))
               .forEach(r => {
-                const tr = document.createElement('tr');
-                const posTd = document.createElement('td');
-                posTd.textContent = r.posicio;
-                tr.appendChild(posTd);
+                const card = document.createElement('div');
+                card.className = 'ranking-card';
+                const posSpan = document.createElement('span');
+                posSpan.textContent = r.posicio;
+                card.appendChild(posSpan);
                 const nom = mapJugadors[r.jugador_id] || r.jugador_id;
-                const nameTd = document.createElement('td');
                 const nameBtn = document.createElement('button');
                 nameBtn.textContent = nom;
                 nameBtn.addEventListener('click', () =>
                   mostraPartidesJugador(r.jugador_id, nom)
                 );
-                nameTd.appendChild(nameBtn);
-                tr.appendChild(nameTd);
+                card.appendChild(nameBtn);
                 const info = jugadors.find(j => j.id === r.jugador_id);
 
                 const pot = disponible(
@@ -165,19 +153,16 @@ export function mostraContinu3B() {
                   info ? info.data_ultim_repte : '',
                   r.posicio
                 );
-                const potTd = document.createElement('td');
                 const potSpan = document.createElement('span');
                 potSpan.textContent = pot ? '🟢' : '🔴';
                 potSpan.title = pot
                   ? 'Pot reptar i ser reptat'
                   : 'No pot reptar ni ser reptat';
-                potTd.appendChild(potSpan);
-                tr.appendChild(potTd);
-                tbody.appendChild(tr);
+                card.appendChild(potSpan);
+                cards.appendChild(card);
               });
-              table.appendChild(tbody);
-              appendResponsiveTable(cont, table);
-            } else {
+            cont.appendChild(cards);
+          } else {
 
             const p = document.createElement('p');
             p.textContent = 'No hi ha rànquing disponible.';

--- a/style.css
+++ b/style.css
@@ -587,4 +587,21 @@ details summary {
   color: #000;
 }
 
+.ranking-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.ranking-card {
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 


### PR DESCRIPTION
## Summary
- Replace ranking table with responsive card layout
- Style ranking cards with flex wrapping and shadows

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0a1979dac832eb4e451c9713b323f