### PR TITLE
Refactor ranking ordering

### DIFF
--- a/js/continu3b.js
+++ b/js/continu3b.js
@@ -160,10 +160,10 @@ export function mostraContinu3B() {
             table.appendChild(thead);
 
             const tbody = document.createElement('tbody');
-            ranking
+            const ordered = ranking
               .slice()
-              .sort((a, b) => parseInt(a.posicio, 10) - parseInt(b.posicio, 10))
-              .forEach((r, idx) => {
+              .sort((a, b) => parseInt(a.posicio) - parseInt(b.posicio));
+            ordered.forEach((r, idx) => {
                 const tr = document.createElement('tr');
                 if (idx < 3) tr.classList.add(`top${idx + 1}`);
 


### PR DESCRIPTION
## Summary
- pre-sort ranking entries before iterating to build table rows

## Testing
- `npm test` *(fails: could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0afd041b0832e831d8153ede04278