### PR TITLE
Ensure ranking legend precedes table

### DIFF
--- a/js/continu3b.js
+++ b/js/continu3b.js
@@ -135,17 +135,6 @@ export function mostraContinu3B() {
           title.textContent = 'Rànquing actual';
           cont.appendChild(title);
           if (Array.isArray(ranking) && ranking.length) {
-            const legenda = document.createElement('div');
-
-              ['🟢 Pot reptar i ser reptat', '🔴 No pot reptar ni ser reptat'].forEach(
-                t => {
-                  const p = document.createElement('p');
-                  p.textContent = t;
-                  legenda.appendChild(p);
-                }
-              );
-
-            cont.appendChild(legenda);
             const table = document.createElement('table');
             table.classList.add('ranking-table');
             const thead = document.createElement('thead');
@@ -207,6 +196,17 @@ export function mostraContinu3B() {
                 tbody.appendChild(tr);
               });
             table.appendChild(tbody);
+            const legenda = document.createElement('div');
+
+            ['🟢 Pot reptar i ser reptat', '🔴 No pot reptar ni ser reptat'].forEach(
+              t => {
+                const p = document.createElement('p');
+                p.textContent = t;
+                legenda.appendChild(p);
+              }
+            );
+
+            cont.appendChild(legenda);
             appendResponsiveTable(cont, table);
           } else {
 


### PR DESCRIPTION
## Summary
- Build ranking table before adding legend and append with `appendResponsiveTable`
- Display green/red availability legend above ranking table

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b13bf368832ea4168ab9f3f00cd7