### PR TITLE
Add Continu 3B match card display

### DIFF
--- a/js/continu3b.js
+++ b/js/continu3b.js
@@ -447,6 +447,65 @@ export function mostraContinu3B() {
         })
       );
 
+      const btnPartides = document.createElement('button');
+      btnPartides.textContent = 'Partides';
+      btnPartides.addEventListener('click', () =>
+        showSection(btnPartides, () => {
+          const title = document.createElement('h3');
+          title.textContent = 'Partides';
+          cont.appendChild(title);
+          if (Array.isArray(partides) && partides.length) {
+            const rankingMap = Object.fromEntries(
+              ranking.map(r => [r.jugador_id, parseInt(r.posicio, 10)])
+            );
+            const sorted = partides
+              .slice()
+              .sort((a, b) => new Date(b.data) - new Date(a.data));
+            sorted.forEach(p => {
+              const card = document.createElement('div');
+              card.classList.add('partida-card');
+              const repte = reptes.find(r => r.id === p.repte_id) || {};
+              const local = mapJugadors[p.local_id] || p.local_id;
+              const visitant = mapJugadors[p.visitant_id] || p.visitant_id;
+              const resultat =
+                p.caramboles_local && p.caramboles_visitant
+                  ? `${p.caramboles_local}-${p.caramboles_visitant}`
+                  : '';
+              const posLocalAfter = rankingMap[p.local_id];
+              const posVisitantAfter = rankingMap[p.visitant_id];
+              const swap = repte.resultat_guanya_reptador === 'TRUE';
+              let posLocalInicial = posLocalAfter;
+              let posVisitantInicial = posVisitantAfter;
+              if (swap && posLocalAfter !== undefined && posVisitantAfter !== undefined) {
+                posLocalInicial = posVisitantAfter;
+                posVisitantInicial = posLocalAfter;
+              }
+              const posLocalText =
+                posLocalInicial !== undefined ? posLocalInicial : '-';
+              const posVisitantText =
+                posVisitantInicial !== undefined ? posVisitantInicial : '-';
+              const swapText = swap
+                ? 'Intercanvi de posicions'
+                : 'No intercanvi de posicions';
+              const date = p.data
+                ? new Date(p.data).toLocaleDateString('ca-ES')
+                : '';
+              card.innerHTML = `
+                <h4>${date}</h4>
+                <p>${local} (Pos. ${posLocalText}) vs ${visitant} (Pos. ${posVisitantText})</p>
+                <p>Resultat: ${resultat}</p>
+                <p>${swapText}</p>
+              `;
+              cont.appendChild(card);
+            });
+          } else {
+            const p = document.createElement('p');
+            p.textContent = 'No hi ha partides registrades.';
+            cont.appendChild(p);
+          }
+        })
+      );
+
       const btnNormativa = document.createElement('button');
       btnNormativa.textContent = 'Normativa';
       btnNormativa.addEventListener('click', () =>
@@ -512,7 +571,7 @@ export function mostraContinu3B() {
         })
       );
 
-      [btnRanking, btnReptes, btnLlista, btnAcces, btnNormativa].forEach(b =>
+      [btnRanking, btnReptes, btnLlista, btnAcces, btnPartides, btnNormativa].forEach(b =>
         btnContainer.appendChild(b)
       );
 

--- a/style.css
+++ b/style.css
@@ -597,4 +597,20 @@ details summary {
 
 }
 
+.partida-card {
+  background: #f8f8f8;
+  border-radius: 12px;
+  padding: 10px;
+  margin-bottom: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.partida-card h4 {
+  margin: 0 0 5px;
+}
+
+.partida-card p {
+  margin: 4px 0;
+}
+
 


### PR DESCRIPTION
## Summary
- Add dedicated **Partides** section for Continu 3B with cards showing players, results, initial positions and swap status.
- Style new match cards.

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b79bc28c832e8948275a93bc6e10