### PR TITLE
Adjust continu3B ranking options and styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -340,20 +340,6 @@ table:not(.agenda-table) tr:nth-child(even) {
   background: #f5f5f5;
 }
 
-.ranking-table .top1 {
-  background: #ffd700;
-  font-weight: bold;
-}
-
-.ranking-table .top2 {
-  background: #c0c0c0;
-  font-weight: bold;
-}
-
-.ranking-table .top3 {
-  background: #cd7f32;
-  font-weight: bold;
-}
 
 
 


### PR DESCRIPTION
## Summary
- Move "Mostra només disponibles" filter below the legend in the active ranking view
- Replace "Últim repte" column with "Dies per reptar/ser reptat" showing remaining cooldown
- Remove special colors for the top three positions so all rows share the same style
- Account for unscheduled challenges: pending proposals expire after 14 days, accepted challenges after 7 days

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0b4463220832ea1d161412f251f40