### PR TITLE
Automate service worker cache versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ AGENDA_ID=1IkA50UI7OpFd_VYUb5kNe9V0jj-MZKqu python3 tools/update_events.py
 
 Abans de fer un build o desplegar, cal actualitzar la versió del
 service worker per garantir que els canvis es propaguin als clients.
+La versió es calcula automàticament a partir del contingut dels fitxers
+que es precachen, de manera que qualsevol canvi genera un valor nou.
 
 ```bash
 python3 tools/update_sw_version.py

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.3/workbox-sw.js');
 
 // This value is replaced at build time by tools/update_sw_version.py
-const CACHE_VERSION = '20250815180044';
+const CACHE_VERSION = 'eadffaa670b0';
 
 self.addEventListener('install', () => self.skipWaiting());
 

--- a/tools/update_sw_version.py
+++ b/tools/update_sw_version.py
@@ -1,23 +1,59 @@
 #!/usr/bin/env python3
-from datetime import datetime, timezone
+"""Update the service worker cache version automatically.
+
+The version is derived from the contents of the files listed in the
+`precacheAndRoute` section of ``service-worker.js``. Any change to these
+files will therefore result in a new cache version without having to
+manually bump a constant.
+"""
+
+import hashlib
 import re
 from pathlib import Path
 
+
 ROOT = Path(__file__).resolve().parent.parent
-SW_PATH = ROOT / 'service-worker.js'
+SW_PATH = ROOT / "service-worker.js"
 
 
-def main():
-    ts = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+def _local_precached_files(content: str) -> list[Path]:
+    """Return Paths for all local files precached by the service worker."""
+    files: list[Path] = []
+    for url in re.findall(r"{\s*url:\s*'([^']+)'", content):
+        # Skip external URLs.
+        if "://" in url:
+            continue
+        path = ROOT / url.lstrip("./")
+        if path.exists():
+            files.append(path)
+    return files
+
+
+def _compute_version(files: list[Path]) -> str:
+    """Return a short SHA256 hash for the given files."""
+    digest = hashlib.sha256()
+    for file in files:
+        digest.update(file.read_bytes())
+    return digest.hexdigest()[:12]
+
+
+def main() -> None:
     content = SW_PATH.read_text()
-    new_content, count = re.subn(r"const CACHE_VERSION = '.*';",
-                                 f"const CACHE_VERSION = '{ts}';",
-                                 content)
+    files = _local_precached_files(content)
+    if not files:
+        raise SystemExit("No precached files found to hash")
+
+    version = _compute_version(files)
+    new_content, count = re.subn(
+        r"const CACHE_VERSION = '.*';",
+        f"const CACHE_VERSION = '{version}';",
+        content,
+    )
     if count == 0:
-        raise SystemExit('CACHE_VERSION not found in service-worker.js')
+        raise SystemExit("CACHE_VERSION not found in service-worker.js")
     SW_PATH.write_text(new_content)
-    print(f'Updated service worker version to {ts}')
+    print(f"Updated service worker version to {version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Compute cache version from hashed precached files
- Document automatic service worker version update

## Testing
- `python3 tools/update_sw_version.py`
- `python3 -m py_compile tools/update_sw_version.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f46c3b18832ebd689d5122df729b