### PR TITLE
feat: cache API data with workbox

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -58,3 +58,35 @@ workbox.routing.registerRoute(
     ],
   })
 );
+
+// Same-origin API requests: Stale While Revalidate
+workbox.routing.registerRoute(
+  ({ url, request }) =>
+    request.destination === '' &&
+    url.origin === self.location.origin &&
+    url.pathname.startsWith('/data/'),
+  new workbox.strategies.StaleWhileRevalidate({
+    cacheName: 'api-data',
+    plugins: [
+      new workbox.expiration.ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 24 * 60 * 60,
+      }),
+    ],
+  })
+);
+
+// Remote API requests: Cache First with 1-day expiration
+workbox.routing.registerRoute(
+  ({ url, request }) =>
+    request.destination === '' && url.origin !== self.location.origin,
+  new workbox.strategies.CacheFirst({
+    cacheName: 'remote-api',
+    plugins: [
+      new workbox.expiration.ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 24 * 60 * 60,
+      }),
+    ],
+  })
+);


### PR DESCRIPTION
## Summary
- handle same-origin API requests with StaleWhileRevalidate
- add CacheFirst strategy for remote API calls to enable offline usage

## Testing
- `python3 -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f5cdabf4832e8d8510c4c58bc10a