### PR TITLE
feat: improve accessibility with ARIA attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,29 +11,29 @@
   <body>
   <div id="app">
     <h1>
-      <img src="icons/icon-192.png" alt="Logo" class="header-logo">Secció de Billar del Foment Martinenc
+      <img src="icons/icon-192.png" alt="Logotip de la Secció de Billar del Foment Martinenc" class="header-logo">Secció de Billar del Foment Martinenc
       <button id="btn-update" aria-label="Actualitza" title="Actualitza">🔄</button>
     </h1>
-    <div id="menu">
-      <button class="menu-toggle" data-target="submenu-billar">Secció Billar</button>
-      <button class="menu-toggle" data-target="submenu-campionats">Campionats en curs</button>
-      <button class="menu-toggle" data-target="submenu-historic">Històric</button>
-      <button class="menu-toggle" data-target="submenu-multimedia">Multimedia</button>
-    </div>
+    <nav id="menu" aria-label="Navegació principal">
+      <button class="menu-toggle" data-target="submenu-billar" aria-controls="submenu-billar" aria-expanded="false" aria-haspopup="true">Secció Billar</button>
+      <button class="menu-toggle" data-target="submenu-campionats" aria-controls="submenu-campionats" aria-expanded="false" aria-haspopup="true">Campionats en curs</button>
+      <button class="menu-toggle" data-target="submenu-historic" aria-controls="submenu-historic" aria-expanded="false" aria-haspopup="true">Històric</button>
+      <button class="menu-toggle" data-target="submenu-multimedia" aria-controls="submenu-multimedia" aria-expanded="false" aria-haspopup="true">Multimedia</button>
+    </nav>
     <div id="submenu-container">
-      <div id="submenu-billar" class="submenu">
+      <div id="submenu-billar" class="submenu" role="navigation" aria-label="Secció Billar" aria-hidden="true">
         <button id="btn-agenda">Agenda Billar</button>
         <button id="btn-horari">Normativa i Horari</button>
       </div>
-      <div id="submenu-campionats" class="submenu">
+      <div id="submenu-campionats" class="submenu" role="navigation" aria-label="Campionats en curs" aria-hidden="true">
         <button id="btn-torneig">Social en curs</button>
         <button id="btn-continu3b">Continu 3B</button>
       </div>
-      <div id="submenu-historic" class="submenu">
+      <div id="submenu-historic" class="submenu" role="navigation" aria-label="Històric" aria-hidden="true">
         <button id="btn-ranking">Rànquings</button>
         <button id="btn-classificacio">Classificacions Socials</button>
       </div>
-      <div id="submenu-multimedia" class="submenu">
+      <div id="submenu-multimedia" class="submenu" role="navigation" aria-label="Multimedia" aria-hidden="true">
         <button id="btn-enllacos">Enllaços Billar</button>
       </div>
     </div>
@@ -71,14 +71,14 @@
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
-  <div id="chart-overlay" style="display:none;">
+  <div id="chart-overlay" role="dialog" aria-modal="true" aria-labelledby="chart-title" style="display:none;">
     <div id="player-chart">
       <div id="chart-header">
         <h3 id="chart-title" style="margin:0.5rem 0;"></h3>
-        <button id="close-chart">Tanca</button>
+        <button id="close-chart" aria-label="Tanca gràfic">Tanca</button>
       </div>
 
-      <canvas id="chart-canvas"></canvas>
+      <canvas id="chart-canvas" role="img" aria-label="Gràfic de l'evolució del jugador"></canvas>
     </div>
   </div>
   <script type="module" src="main.js"></script>

--- a/js/graficos.js
+++ b/js/graficos.js
@@ -1,5 +1,7 @@
 import { ranquing, lineChart, setLineChart, adjustChartSize } from './init.js';
 
+let lastFocusedElement = null;
+
 export function mostraEvolucioJugador(jugador, nom) {
   const modalitats = ['3 BANDES', 'BANDA', 'LLIURE'];
   const dadesPerMod = modalitats.map(mod =>
@@ -33,6 +35,11 @@ export function mostraEvolucioJugador(jugador, nom) {
   const overlay = document.getElementById('chart-overlay');
   if (overlay) {
     overlay.style.display = 'flex';
+    lastFocusedElement = document.activeElement;
+  }
+  const closeBtn = document.getElementById('close-chart');
+  if (closeBtn) {
+    closeBtn.focus();
   }
   adjustChartSize();
 
@@ -93,6 +100,10 @@ export function closeChart() {
   if (lineChart) {
     lineChart.destroy();
     setLineChart(null);
+  }
+  if (lastFocusedElement) {
+    lastFocusedElement.focus();
+    lastFocusedElement = null;
   }
 }
 

--- a/main.js
+++ b/main.js
@@ -17,8 +17,20 @@ document.querySelectorAll('.menu-toggle').forEach(btn => {
     const isVisible = target.style.display === 'flex';
     document.querySelectorAll('.submenu').forEach(sm => {
       sm.style.display = 'none';
+      sm.setAttribute('aria-hidden', 'true');
     });
-    target.style.display = isVisible ? 'none' : 'flex';
+    document.querySelectorAll('.menu-toggle').forEach(b => b.setAttribute('aria-expanded', 'false'));
+    if (!isVisible) {
+      target.style.display = 'flex';
+      target.setAttribute('aria-hidden', 'false');
+      btn.setAttribute('aria-expanded', 'true');
+      const firstButton = target.querySelector('button');
+      if (firstButton) firstButton.focus();
+    } else {
+      target.style.display = 'none';
+      target.setAttribute('aria-hidden', 'true');
+      btn.setAttribute('aria-expanded', 'false');
+    }
     document.getElementById('filters-row').style.display = 'none';
     document.getElementById('classificacio-filters').style.display = 'none';
     document.getElementById('torneig-buttons').style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -115,6 +115,11 @@ button:active {
   transform: scale(0.98);
 }
 
+button:focus {
+  outline: 3px solid #ff0;
+  outline-offset: 2px;
+}
+
 
 /* Ensure grouped buttons are responsive and share equal width */
 .button-group {


### PR DESCRIPTION
## Summary
- add ARIA labels and roles to navigation menus and chart dialog
- manage keyboard focus for menus and chart modal
- highlight keyboard focus with CSS outline

## Testing
- `python -m py_compile server.py`
- `node --check main.js js/graficos.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0f6a3230c832e91fc090c213846d5