### PR TITLE
Refactor PWA state to remove circular dependencies

### DIFF
--- a/src/js/agenda.js
+++ b/src/js/agenda.js
@@ -1,4 +1,4 @@
-import { events, agendaSetmanaInici, appendResponsiveTable } from './init.js';
+import { state, appendResponsiveTable } from './state.js';
 
 export function mostraAgenda() {
   const cont = document.getElementById('content');
@@ -14,11 +14,11 @@ export function mostraAgenda() {
   const label = document.createElement('span');
   label.id = 'calendar-month';
   prev.addEventListener('click', () => {
-    agendaSetmanaInici.setDate(agendaSetmanaInici.getDate() - 7);
+    state.agendaSetmanaInici.setDate(state.agendaSetmanaInici.getDate() - 7);
     render();
   });
   next.addEventListener('click', () => {
-    agendaSetmanaInici.setDate(agendaSetmanaInici.getDate() + 7);
+    state.agendaSetmanaInici.setDate(state.agendaSetmanaInici.getDate() + 7);
     render();
   });
   nav.appendChild(prev);
@@ -53,14 +53,14 @@ export function mostraAgenda() {
     const row = document.createElement('tr');
     for (let i = 0; i < 7; i++) {
       const cell = document.createElement('td');
-      const date = new Date(agendaSetmanaInici);
-      date.setDate(agendaSetmanaInici.getDate() + i);
+      const date = new Date(state.agendaSetmanaInici);
+      date.setDate(state.agendaSetmanaInici.getDate() + i);
       const iso = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
         .toISOString()
         .split('T')[0];
       cell.textContent = date.getDate();
       cell.dataset.date = iso;
-      const dayEvents = events.filter(ev => ev['Data'] === iso);
+      const dayEvents = state.events.filter(ev => ev['Data'] === iso);
       if (dayEvents.length > 0) {
         let cls = 'event-other';
         if (dayEvents.some(ev => ev.Tipus === 'festiu')) {
@@ -97,7 +97,7 @@ export function mostraAgenda() {
       header.appendChild(th);
     });
     listTable.appendChild(header);
-    const dayEvents = events
+    const dayEvents = state.events
       .filter(ev => ev['Data'] === selectedDate)
       .sort((a, b) => (a['Hora'] || '').localeCompare(b['Hora'] || ''));
     dayEvents.forEach(ev => {
@@ -131,14 +131,14 @@ export function mostraAgenda() {
   }
 
   function render() {
-    const end = new Date(agendaSetmanaInici);
-    end.setDate(agendaSetmanaInici.getDate() + 6);
-    const weekEnd = new Date(agendaSetmanaInici);
-    weekEnd.setDate(agendaSetmanaInici.getDate() + 7);
-    if (new Date(selectedDate) < agendaSetmanaInici || new Date(selectedDate) >= weekEnd) {
-      selectedDate = agendaSetmanaInici.toISOString().split('T')[0];
+    const end = new Date(state.agendaSetmanaInici);
+    end.setDate(state.agendaSetmanaInici.getDate() + 6);
+    const weekEnd = new Date(state.agendaSetmanaInici);
+    weekEnd.setDate(state.agendaSetmanaInici.getDate() + 7);
+    if (new Date(selectedDate) < state.agendaSetmanaInici || new Date(selectedDate) >= weekEnd) {
+      selectedDate = state.agendaSetmanaInici.toISOString().split('T')[0];
     }
-    const startStr = agendaSetmanaInici.toLocaleDateString('ca-ES', { day: 'numeric', month: 'short' });
+    const startStr = state.agendaSetmanaInici.toLocaleDateString('ca-ES', { day: 'numeric', month: 'short' });
     const endStr = end.toLocaleDateString('ca-ES', { day: 'numeric', month: 'short', year: 'numeric' });
     label.textContent = `${startStr} - ${endStr}`;
     renderCalendar();

--- a/src/js/calendari.js
+++ b/src/js/calendari.js
@@ -1,4 +1,4 @@
-import { appendResponsiveTable } from './init.js';
+import { appendResponsiveTable } from './state.js';
 
 export function mostraCalendari(partides) {
   const cont = document.getElementById('content');

--- a/src/js/classificacio.js
+++ b/src/js/classificacio.js
@@ -1,4 +1,4 @@
-import { classificacions, classAnySeleccionat, classModalitatSeleccionada, classCategoriaSeleccionada, appendResponsiveTable } from './init.js';
+import { state, appendResponsiveTable } from './state.js';
 
 export function mostraClassificacio() {
   const cont = document.getElementById('content');
@@ -12,12 +12,12 @@ export function mostraClassificacio() {
   });
   taula.appendChild(cap);
 
-  const dades = classificacions
+  const dades = state.classificacions
     .filter(
       r =>
-        parseInt(r.Any, 10) === classAnySeleccionat &&
-        r.Modalitat === classModalitatSeleccionada &&
-        r.Categoria === classCategoriaSeleccionada
+        parseInt(r.Any, 10) === state.classAnySeleccionat &&
+        r.Modalitat === state.classModalitatSeleccionada &&
+        r.Categoria === state.classCategoriaSeleccionada
     )
     .sort((a, b) => parseInt(a.Posició, 10) - parseInt(b.Posició, 10));
 

--- a/src/js/continu3b.js
+++ b/src/js/continu3b.js
@@ -1,4 +1,4 @@
-import { appendResponsiveTable } from "./init.js";
+import { appendResponsiveTable } from './state.js';
 
 export function mostraContinu3B() {
   const cont = document.getElementById('content');

--- a/src/js/graficos.js
+++ b/src/js/graficos.js
@@ -1,11 +1,11 @@
-import { ranquing, lineChart, setLineChart, adjustChartSize } from './init.js';
+import { state, setLineChart, adjustChartSize } from './state.js';
 
 let lastFocusedElement = null;
 
 export function mostraEvolucioJugador(jugador, nom) {
   const modalitats = ['3 BANDES', 'BANDA', 'LLIURE'];
   const dadesPerMod = modalitats.map(mod =>
-    ranquing
+    state.ranquing
       .filter(r => r.Jugador === jugador && r.Modalitat === mod)
       .map(r => ({ any: parseInt(r.Any, 10), mitjana: parseFloat(r.Mitjana) }))
       .sort((a, b) => a.any - b.any)
@@ -49,8 +49,8 @@ export function mostraEvolucioJugador(jugador, nom) {
   }
 
   const ctx = canvas.getContext('2d');
-  if (lineChart) {
-    lineChart.destroy();
+  if (state.lineChart) {
+    state.lineChart.destroy();
   }
   setLineChart(new Chart(ctx, {
     type: 'line',
@@ -97,8 +97,8 @@ export function closeChart() {
   if (title) {
     title.textContent = '';
   }
-  if (lineChart) {
-    lineChart.destroy();
+  if (state.lineChart) {
+    state.lineChart.destroy();
     setLineChart(null);
   }
   if (lastFocusedElement) {

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -1,55 +1,6 @@
 import { mostraRanquing } from './ranking.js';
 import { mostraClassificacio } from './classificacio.js';
-
-export let ranquing = [];
-export let anys = [];
-export let anySeleccionat = null;
-export let modalitatSeleccionada = '3 BANDES';
-export let lineChart = null;
-
-export let classificacions = [];
-export let classYears = [];
-export let classAnySeleccionat = null;
-export let classModalitatSeleccionada = '3 BANDES';
-export let classCategoriaSeleccionada = null;
-
-export let events = [];
-export let agendaSetmanaInici = (() => {
-  const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
-  return d;
-})();
-export let torneigModalitat = '';
-export let torneigCaramboles = {};
-export let torneigCategoriaSeleccionada = null;
-
-export function setLineChart(chart) {
-  lineChart = chart;
-}
-
-export function appendResponsiveTable(container, table) {
-  const wrapper = document.createElement('div');
-  wrapper.className = 'table-responsive';
-  wrapper.appendChild(table);
-  container.appendChild(wrapper);
-}
-
-export function adjustChartSize() {
-  const chartContainer = document.getElementById('player-chart');
-  if (chartContainer) {
-    chartContainer.style.width = '90vw';
-    chartContainer.style.height = '96vh';
-  }
-  const canvas = document.getElementById('chart-canvas');
-  if (canvas) {
-    canvas.style.width = '100%';
-    canvas.style.height = '100%';
-  }
-  if (lineChart) {
-    lineChart.resize();
-  }
-}
+import { state } from './state.js';
 
 export function inicialitza() {
   Promise.all([
@@ -60,19 +11,19 @@ export function inicialitza() {
     fetch('data/festius.json').then(r => r.json()).catch(() => [])
   ])
     .then(([dadesRanking, dadesClass, dadesEvents, dadesCalendari, dadesFestius]) => {
-      ranquing = dadesRanking;
-      anys = [...new Set(dadesRanking.map(d => parseInt(d.Any, 10)))]
+      state.ranquing = dadesRanking;
+      state.anys = [...new Set(dadesRanking.map(d => parseInt(d.Any, 10)))]
         .sort((a, b) => a - b);
-      anySeleccionat = anys[anys.length - 1];
+      state.anySeleccionat = state.anys[state.anys.length - 1];
 
-      classificacions = dadesClass;
-      classYears = [...new Set(dadesClass.map(d => parseInt(d.Any, 10)))]
+      state.classificacions = dadesClass;
+      state.classYears = [...new Set(dadesClass.map(d => parseInt(d.Any, 10)))]
         .sort((a, b) => a - b);
-      classAnySeleccionat = classYears[classYears.length - 1] || null;
+      state.classAnySeleccionat = state.classYears[state.classYears.length - 1] || null;
       const categories = new Set(dadesClass.map(d => d.Categoria));
-      classCategoriaSeleccionada = categories.values().next().value || null;
+      state.classCategoriaSeleccionada = categories.values().next().value || null;
 
-      events = dadesEvents
+      state.events = dadesEvents
         .map(ev => {
           const titol = ev['Títol'] || ev['Titol'] || '';
           return {
@@ -110,25 +61,25 @@ export function inicialitza() {
 export function preparaSelectors() {
   const select = document.getElementById('year-select');
   select.innerHTML = '';
-  anys.slice().sort((a, b) => b - a).forEach(any => {
+  state.anys.slice().sort((a, b) => b - a).forEach(any => {
     const opt = document.createElement('option');
     opt.value = any;
     opt.textContent = any;
-    if (any === anySeleccionat) opt.selected = true;
+    if (any === state.anySeleccionat) opt.selected = true;
     select.appendChild(opt);
   });
   select.addEventListener('change', () => {
-    anySeleccionat = parseInt(select.value, 10);
+    state.anySeleccionat = parseInt(select.value, 10);
     mostraRanquing();
   });
 
   const cont = document.getElementById('modalitat-buttons');
   cont.querySelectorAll('button').forEach(btn => {
-    if (btn.dataset.mod === modalitatSeleccionada) {
+    if (btn.dataset.mod === state.modalitatSeleccionada) {
       btn.classList.add('selected');
     }
     btn.addEventListener('click', () => {
-      modalitatSeleccionada = btn.dataset.mod;
+      state.modalitatSeleccionada = btn.dataset.mod;
       cont.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
       btn.classList.add('selected');
       mostraRanquing();
@@ -139,25 +90,25 @@ export function preparaSelectors() {
 export function preparaSelectorsClassificacio() {
   const yearSel = document.getElementById('classificacio-year-select');
   yearSel.innerHTML = '';
-  classYears.slice().sort((a, b) => b - a).forEach(any => {
+  state.classYears.slice().sort((a, b) => b - a).forEach(any => {
     const opt = document.createElement('option');
     opt.value = any;
     opt.textContent = any;
-    if (any === classAnySeleccionat) opt.selected = true;
+    if (any === state.classAnySeleccionat) opt.selected = true;
     yearSel.appendChild(opt);
   });
   yearSel.addEventListener('change', () => {
-    classAnySeleccionat = parseInt(yearSel.value, 10);
+    state.classAnySeleccionat = parseInt(yearSel.value, 10);
     mostraClassificacio();
   });
 
   const modalBtns = document.getElementById('classificacio-modalitat-buttons');
   modalBtns.querySelectorAll('button').forEach(btn => {
-    if (btn.dataset.mod === classModalitatSeleccionada) {
+    if (btn.dataset.mod === state.classModalitatSeleccionada) {
       btn.classList.add('selected');
     }
     btn.addEventListener('click', () => {
-      classModalitatSeleccionada = btn.dataset.mod;
+      state.classModalitatSeleccionada = btn.dataset.mod;
       modalBtns.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
       btn.classList.add('selected');
       mostraClassificacio();
@@ -166,13 +117,13 @@ export function preparaSelectorsClassificacio() {
 
   const catBtns = document.getElementById('categoria-buttons');
   catBtns.innerHTML = '';
-  const cats = [...new Set(classificacions.map(c => c.Categoria))].sort();
+  const cats = [...new Set(state.classificacions.map(c => c.Categoria))].sort();
   cats.forEach(cat => {
     const btn = document.createElement('button');
     btn.textContent = cat;
-    if (cat === classCategoriaSeleccionada) btn.classList.add('selected');
+    if (cat === state.classCategoriaSeleccionada) btn.classList.add('selected');
     btn.addEventListener('click', () => {
-      classCategoriaSeleccionada = cat;
+      state.classCategoriaSeleccionada = cat;
       catBtns.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
       btn.classList.add('selected');
       mostraClassificacio();
@@ -186,20 +137,20 @@ export function preparaTorneigCategories(categories, render) {
   cont.innerHTML = '';
   if (!categories || categories.length === 0) {
     cont.style.display = 'none';
-    torneigCategoriaSeleccionada = null;
+    state.torneigCategoriaSeleccionada = null;
     render();
     return;
   }
   categories.sort();
-  if (!torneigCategoriaSeleccionada || !categories.includes(torneigCategoriaSeleccionada)) {
-    torneigCategoriaSeleccionada = categories[0];
+  if (!state.torneigCategoriaSeleccionada || !categories.includes(state.torneigCategoriaSeleccionada)) {
+    state.torneigCategoriaSeleccionada = categories[0];
   }
   categories.forEach(cat => {
     const btn = document.createElement('button');
     btn.textContent = `${cat}a`;
-    if (cat === torneigCategoriaSeleccionada) btn.classList.add('selected');
+    if (cat === state.torneigCategoriaSeleccionada) btn.classList.add('selected');
     btn.addEventListener('click', () => {
-      torneigCategoriaSeleccionada = cat;
+      state.torneigCategoriaSeleccionada = cat;
       cont.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
       btn.classList.add('selected');
       render();

--- a/src/js/partides.js
+++ b/src/js/partides.js
@@ -1,4 +1,4 @@
-import { appendResponsiveTable, torneigCategoriaSeleccionada } from './init.js';
+import { appendResponsiveTable, state } from './state.js';
 
 export function mostraPartides(partides) {
   const cont = document.getElementById('content');
@@ -32,7 +32,7 @@ export function mostraPartides(partides) {
     filtre = (filtre || '').toLowerCase();
     list.innerHTML = '';
     const filtered = partides
-      .filter(p => p["🏆 Categoria de la partida"] === torneigCategoriaSeleccionada)
+      .filter(p => p["🏆 Categoria de la partida"] === state.torneigCategoriaSeleccionada)
       .filter(p => {
         if (!filtre) return true;
         const nom1 = (p["🎱 Nom del Jugador 1"] || '').trim().toLowerCase();

--- a/src/js/ranking.js
+++ b/src/js/ranking.js
@@ -1,4 +1,4 @@
-import { ranquing, anySeleccionat, modalitatSeleccionada, appendResponsiveTable } from './init.js';
+import { state, appendResponsiveTable } from './state.js';
 import { mostraEvolucioJugador } from './graficos.js';
 
 export function mostraRanquing() {
@@ -13,11 +13,11 @@ export function mostraRanquing() {
   });
   taula.appendChild(cap);
 
-  const dadesOrdenades = ranquing
+  const dadesOrdenades = state.ranquing
     .filter(
       reg =>
-        parseInt(reg.Any, 10) === anySeleccionat &&
-        reg.Modalitat === modalitatSeleccionada
+        parseInt(reg.Any, 10) === state.anySeleccionat &&
+        reg.Modalitat === state.modalitatSeleccionada
     )
     .sort((a, b) => parseFloat(b.Mitjana) - parseFloat(a.Mitjana));
 

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -1,0 +1,49 @@
+export const state = {
+  ranquing: [],
+  anys: [],
+  anySeleccionat: null,
+  modalitatSeleccionada: '3 BANDES',
+  lineChart: null,
+  classificacions: [],
+  classYears: [],
+  classAnySeleccionat: null,
+  classModalitatSeleccionada: '3 BANDES',
+  classCategoriaSeleccionada: null,
+  events: [],
+  agendaSetmanaInici: (() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+    return d;
+  })(),
+  torneigModalitat: '',
+  torneigCaramboles: {},
+  torneigCategoriaSeleccionada: null,
+};
+
+export function setLineChart(chart) {
+  state.lineChart = chart;
+}
+
+export function appendResponsiveTable(container, table) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'table-responsive';
+  wrapper.appendChild(table);
+  container.appendChild(wrapper);
+}
+
+export function adjustChartSize() {
+  const chartContainer = document.getElementById('player-chart');
+  if (chartContainer) {
+    chartContainer.style.width = '90vw';
+    chartContainer.style.height = '96vh';
+  }
+  const canvas = document.getElementById('chart-canvas');
+  if (canvas) {
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+  }
+  if (state.lineChart) {
+    state.lineChart.resize();
+  }
+}

--- a/src/js/torneig.js
+++ b/src/js/torneig.js
@@ -1,4 +1,5 @@
-import { preparaTorneigCategories, appendResponsiveTable, torneigCategoriaSeleccionada, torneigCaramboles } from './init.js';
+import { preparaTorneigCategories } from './init.js';
+import { appendResponsiveTable, state } from './state.js';
 import { mostraCalendari } from './calendari.js';
 import { mostraPartides } from './partides.js';
 
@@ -48,9 +49,9 @@ export function mostraTorneig(dades, file) {
     const categories = Object.keys(agrupats);
     const render = () => {
       cont.innerHTML = '';
-      const cat = torneigCategoriaSeleccionada;
+      const cat = state.torneigCategoriaSeleccionada;
       const h3 = document.createElement('h3');
-      const car = torneigCaramboles[cat];
+      const car = state.torneigCaramboles[cat];
       h3.textContent = car
         ? `${cat}a categoria (${car} caramboles)`
         : `${cat}a categoria`;
@@ -77,9 +78,9 @@ export function mostraTorneig(dades, file) {
     const categories = Object.keys(agrupats);
     const render = () => {
       cont.innerHTML = '';
-      const cat = torneigCategoriaSeleccionada;
+      const cat = state.torneigCategoriaSeleccionada;
       const h3 = document.createElement('h3');
-      const car = torneigCaramboles[cat];
+      const car = state.torneigCaramboles[cat];
       h3.textContent = car
         ? `${cat}a categoria (${car} caramboles)`
         : `${cat}a categoria`;
@@ -141,9 +142,9 @@ export function mostraTorneig(dades, file) {
     const categories = Object.keys(agrupats);
     const render = () => {
       cont.innerHTML = '';
-      const cat = torneigCategoriaSeleccionada;
+      const cat = state.torneigCategoriaSeleccionada;
       const h3 = document.createElement('h3');
-      const car = torneigCaramboles[cat];
+      const car = state.torneigCaramboles[cat];
       h3.textContent = car
         ? `${cat}a categoria (${car} caramboles)`
         : `${cat}a categoria`;


### PR DESCRIPTION
## Summary
- centralize shared runtime state and helpers in `state.js`
- update modules to read/write state through the new module
- eliminate build-time circular dependency warnings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a19f94ea7c832e87f5e4dd2b75ecf7