### PR TITLE
Protect update endpoints with admin code check

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ generar els fitxers compilats:
 npm install
 npm run build
 python3 tools/update_sw_version.py
+export ADMIN_CODE=el_teu_codi_secret
 python3 server.py
+```
+
+Per executar els workflows de GitHub Actions amb accés administratiu,
+desa aquest codi a **Settings → Secrets and variables → Actions** com a
+secret `ADMIN_CODE` i exposa'l a les tasques amb:
+
+```yaml
+env:
+  ADMIN_CODE: ${{ secrets.ADMIN_CODE }}
 ```
 
 Aquesta darrera ordre arrenca un petit servidor web a
@@ -29,6 +39,9 @@ De la mateixa manera, els esdeveniments es sincronitzen d'un Google Sheet públi
 ```bash
 AGENDA_ID=1IkA50UI7OpFd_VYUb5kNe9V0jj-MZKqu python3 tools/update_events.py
 ```
+
+Els endpoints `/update-*` requereixen enviar el mateix codi mitjançant el
+capçal `X-Admin-Code` o el paràmetre de consulta `code`.
 
 ### Actualitzar la versió del service worker
 

--- a/server.py
+++ b/server.py
@@ -3,13 +3,34 @@ import socketserver
 import subprocess
 import os
 from pathlib import Path
+from urllib.parse import urlparse, parse_qs
 
 PORT = 8000
 WEB_DIR = Path(__file__).resolve().parent
 
+def verify_access(request: http.server.BaseHTTPRequestHandler) -> bool:
+    """Return True if the request provides the correct admin code via header or query."""
+    code = request.headers.get('X-Admin-Code')
+    if code is None:
+        parsed = urlparse(request.path)
+        params = parse_qs(parsed.query)
+        code = (
+            params.get('code', [None])[0]
+            or params.get('admin_code', [None])[0]
+            or params.get('X-Admin-Code', [None])[0]
+        )
+    expected = os.environ.get('ADMIN_CODE')
+    return expected is not None and code == expected
+
+
 class Handler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
-        if self.path == '/update-ranking':
+        parsed_path = urlparse(self.path)
+        if parsed_path.path == '/update-ranking':
+            if not verify_access(self):
+                self.send_response(403)
+                self.end_headers()
+                return
             try:
                 subprocess.run(['python3', 'update_ranquing.py'], check=True)
                 self.send_response(200)
@@ -20,7 +41,11 @@ class Handler(http.server.SimpleHTTPRequestHandler):
                 self.send_response(500)
                 self.end_headers()
             return
-        if self.path == '/update-classificacions':
+        if parsed_path.path == '/update-classificacions':
+            if not verify_access(self):
+                self.send_response(403)
+                self.end_headers()
+                return
             try:
                 subprocess.run(['python3', 'update_classificacions.py'], check=True)
                 self.send_response(200)
@@ -31,7 +56,11 @@ class Handler(http.server.SimpleHTTPRequestHandler):
                 self.send_response(500)
                 self.end_headers()
             return
-        if self.path == '/update-events':
+        if parsed_path.path == '/update-events':
+            if not verify_access(self):
+                self.send_response(403)
+                self.end_headers()
+                return
             try:
                 subprocess.run(['python3', 'update_events.py'], check=True)
                 self.send_response(200)


### PR DESCRIPTION
## Summary
- add `verify_access` to check admin code from header or query
- secure `/update-*` endpoints with admin code validation
- document `ADMIN_CODE` setup for local use and GitHub Actions

## Testing
- `python -m py_compile server.py`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab1eea4394832ebfd91523a242ce6a