### PR TITLE
Refactor server update endpoints

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,9 +1,9 @@
 import http.server
+import os
 import socketserver
 import subprocess
-import os
 from pathlib import Path
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 PORT = 8000
 WEB_DIR = Path(__file__).resolve().parent
@@ -24,49 +24,28 @@ def verify_access(request: http.server.BaseHTTPRequestHandler) -> bool:
 
 
 class Handler(http.server.SimpleHTTPRequestHandler):
-    def do_GET(self):
+    """Serve static files and provide endpoints to update cached data."""
+
+    SCRIPTS = {
+        "/update-ranking": "tools/update_ranquing.py",
+        "/update-classificacions": "tools/update_classificacions.py",
+        "/update-events": "tools/update_events.py",
+    }
+
+    def do_GET(self) -> None:  # noqa: D401 - inherited docs
         parsed_path = urlparse(self.path)
-        if parsed_path.path == '/update-ranking':
+        script = self.SCRIPTS.get(parsed_path.path)
+        if script:
             if not verify_access(self):
                 self.send_response(403)
                 self.end_headers()
                 return
             try:
-                subprocess.run(['python3', 'update_ranquing.py'], check=True)
+                subprocess.run(["python3", str(WEB_DIR / script)], check=True)
                 self.send_response(200)
-                self.send_header('Content-Type', 'application/json')
+                self.send_header("Content-Type", "application/json")
                 self.end_headers()
-                self.wfile.write(b'{"status": "ok"}')
-            except subprocess.CalledProcessError:
-                self.send_response(500)
-                self.end_headers()
-            return
-        if parsed_path.path == '/update-classificacions':
-            if not verify_access(self):
-                self.send_response(403)
-                self.end_headers()
-                return
-            try:
-                subprocess.run(['python3', 'update_classificacions.py'], check=True)
-                self.send_response(200)
-                self.send_header('Content-Type', 'application/json')
-                self.end_headers()
-                self.wfile.write(b'{"status": "ok"}')
-            except subprocess.CalledProcessError:
-                self.send_response(500)
-                self.end_headers()
-            return
-        if parsed_path.path == '/update-events':
-            if not verify_access(self):
-                self.send_response(403)
-                self.end_headers()
-                return
-            try:
-                subprocess.run(['python3', 'update_events.py'], check=True)
-                self.send_response(200)
-                self.send_header('Content-Type', 'application/json')
-                self.end_headers()
-                self.wfile.write(b'{"status": "ok"}')
+                self.wfile.write(b"{\"status\": \"ok\"}")
             except subprocess.CalledProcessError:
                 self.send_response(500)
                 self.end_headers()


### PR DESCRIPTION
## Summary
- refactor HTTP handler to map update endpoints to scripts and dedupe logic
- fix script paths to use tools directory for update commands

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab54e2a834832eb9abd55d65d467ec