### PR TITLE
fix: remove stray character in update events script

### DIFF
--- a/tools/update_events.py
+++ b/tools/update_events.py
@@ -188,7 +188,6 @@ def main() -> None:
                         row["Tipus"] = ""
                     if key != "Tipus":
                         row.pop(key, None)
-n
                 rows.append(row)
     normalise_mitjana_fields(rows if rows else data)
     if write_if_changed(OUTPUT_FILE, rows if rows else data):


### PR DESCRIPTION
## Summary
- fix NameError in `tools/update_events.py`

## Testing
- `python -m py_compile tools/update_events.py`
- `HTTP_TIMEOUT=1 HTTP_RETRIES=1 AGENDA_ID=foo python tools/update_events.py` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adff11b914832eb484b98ba281e08e