### PR TITLE
Handle fetch error in reptes management

### DIFF
--- a/src/js/gestioReptes.js
+++ b/src/js/gestioReptes.js
@@ -14,13 +14,16 @@ export async function mostraGestioReptes(container) {
 
   try {
     const res = await fetch('/api/challenges');
+    if (!res.ok) {
+      throw new Error(res.statusText);
+    }
     const data = await res.json();
     const pre = document.createElement('pre');
     pre.textContent = JSON.stringify(data, null, 2);
     container.appendChild(pre);
   } catch (err) {
     const p = document.createElement('p');
-    p.textContent = 'Error carregant reptes';
+    p.textContent = `Error carregant reptes: ${err.message}`;
     container.appendChild(p);
   }
 }


### PR DESCRIPTION
## Summary
- Check fetch response before parsing challenges
- Show detailed error message when challenges fetch fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b587b7e368832e8d78ada24f0b5be6