### PR TITLE
Remove metadata creation from API and document Alembic migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ npm run build
 python3 tools/update_sw_version.py
 export ADMIN_CODE=el_teu_codi_secret
 echo "window.ADMIN_CODE='${ADMIN_CODE}';" > admin-config.js
+alembic upgrade head
 python3 server.py
 ```
+
+L'ordre `alembic upgrade head` crea o actualitza les taules de la base de
+dades aplicant les migracions.
 
 Per executar els workflows de GitHub Actions amb accés administratiu,
 desa aquest codi a **Settings → Secrets and variables → Actions** com a

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,9 +1,7 @@
 from fastapi import FastAPI, Depends
 from sqlalchemy.orm import Session
-from .database import SessionLocal, engine
+from .database import SessionLocal
 from . import models, schemas
-
-models.Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- stop creating tables automatically in `backend/api.py`
- document running `alembic upgrade head` during deployment
- note: tests already create tables explicitly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b587ba1f38832e802fad361f1154a1