### PR TITLE
Allow configuring database via DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ echo "window.ADMIN_CODE='${ADMIN_CODE}';" > admin-config.js
 python3 server.py
 ```
 
+Per canviar la ubicació de la base de dades, defineix la variable
+d'entorn `DATABASE_URL`. Per defecte s'utilitza `sqlite:///./app.db`.
+
 Per executar els workflows de GitHub Actions amb accés administratiu,
 desa aquest codi a **Settings → Secrets and variables → Actions** com a
 secret `ADMIN_CODE` i exposa'l a les tasques amb:

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,7 +1,8 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-DATABASE_URL = "sqlite:///./app.db"
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
 
 engine = create_engine(
     DATABASE_URL, connect_args={"check_same_thread": False}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import os
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from fastapi.testclient import TestClient

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,5 @@
+import os
+os.environ['DATABASE_URL'] = 'sqlite:///./test.db'
 from fastapi.testclient import TestClient
 
 from server import app


### PR DESCRIPTION
## Summary
- Read `DATABASE_URL` from environment with SQLite fallback
- Document and test using `DATABASE_URL`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b587bae39c832ea27e7ec944cd3fd5