### PR TITLE
docs: clarify dev server ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 alembic upgrade head
 python seed.py
-uvicorn app.main:app --reload
+uvicorn app.main:app --reload --port 8000
 ```
 
 El token d'administració es configura a `app/config.py` (`secret` per defecte). Les peticions POST han d'incloure l'header `X-Admin-Token`.
@@ -19,8 +19,9 @@ El token d'administració es configura a `app/config.py` (`secret` per defecte).
 La PWA es pot servir amb qualsevol servidor estàtic (p.ex. GitHub Pages). Per desenvolupament:
 
 ```bash
-python -m http.server --directory frontend 8000
+python -m http.server --directory frontend 8001
 ```
+Configura `API_BASE` del frontend perquè apunti a `http://localhost:8000/api`.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- document backend dev server on port 8000
- serve frontend on port 8001 and note API_BASE

## Testing
- `pytest` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b58d576ad8832e8d288179455d5f2a