### PR TITLE
Use Supabase token for admin verification

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,59 @@
+from fastapi import Request, HTTPException, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+import requests
+
+from .config import settings
+from .db import get_db
+
+
+def verify_admin(request: Request, db: Session = Depends(get_db)) -> None:
+    """Ensure the requester is an admin user.
+
+    Reads the Supabase auth token from the ``sb-access-token`` cookie or the
+    ``Authorization`` header. It retrieves the user via Supabase Auth and then
+    checks admin rights by executing ``select public.is_admin(email)`` against
+    the database.  HTTP exceptions are raised according to the validation
+    result.
+    """
+
+    token = request.cookies.get("sb-access-token")
+    if not token:
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer "):
+            token = auth[7:]
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing Supabase session")
+
+    if not settings.supabase_url or not settings.supabase_service_key:
+        raise HTTPException(status_code=500, detail="Supabase configuration missing")
+
+    try:
+        resp = requests.get(
+            f"{settings.supabase_url}/auth/v1/user",
+            headers={
+                "apikey": settings.supabase_service_key,
+                "Authorization": f"Bearer {token}",
+            },
+            timeout=10,
+        )
+    except requests.RequestException as exc:  # pragma: no cover - network error
+        raise HTTPException(status_code=500, detail="Error contacting Supabase") from exc
+
+    if resp.status_code != 200:
+        raise HTTPException(status_code=401, detail="Invalid Supabase session")
+
+    email = resp.json().get("email")
+    if not email:
+        raise HTTPException(status_code=401, detail="Invalid Supabase session")
+
+    try:
+        result = db.execute(text("select public.is_admin(:email)"), {"email": email})
+        is_admin = result.scalar()
+    except Exception as exc:  # pragma: no cover - DB error path
+        raise HTTPException(status_code=500, detail="Error checking admin status") from exc
+
+    if not is_admin:
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+
+    # function returns None if admin; FastAPI treats lack of exception as success

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,5 +3,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     database_url: str = "sqlite:///./app.db"
     admin_token: str = "secret"
+    supabase_url: str = ""
+    supabase_service_key: str = ""
 
 settings = Settings()

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,16 +1,13 @@
 from datetime import datetime
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from ..db import get_db
-from ..config import settings
 from .. import models, crud
 from ..services import ranking
+from ..auth import verify_admin
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
-def verify_admin(token: str = Header(None, alias="X-Admin-Token")):
-    if token != settings.admin_token:
-        raise HTTPException(status_code=401, detail="Invalid admin token")
 
 @router.post("/leave", dependencies=[Depends(verify_admin)])
 def voluntary_leave(player_id: int, db: Session = Depends(get_db)):

--- a/backend/app/routers/challenges.py
+++ b/backend/app/routers/challenges.py
@@ -1,16 +1,12 @@
-from fastapi import APIRouter, Depends, HTTPException, Header
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from ..db import get_db
 from .. import schemas
 from ..services import challenges as svc_challenges
-from ..config import settings
+from ..auth import verify_admin
 
 router = APIRouter(prefix="/api", tags=["challenges"])
 
-
-def verify_admin(token: str = Header(None, alias="X-Admin-Token")):
-    if token != settings.admin_token:
-        raise HTTPException(status_code=401, detail="Invalid admin token")
 
 @router.post("/challenges", response_model=schemas.ChallengeBase, dependencies=[Depends(verify_admin)])
 def create_challenge(payload: schemas.ChallengeCreate, db: Session = Depends(get_db)):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ APScheduler
 python-dateutil
 pytest
 pydantic-settings
+requests


### PR DESCRIPTION
## Summary
- Add Supabase-based admin guard reading `sb-access-token` cookie or `Authorization` header
- Query `public.is_admin(email)` to check privileges and return proper HTTP errors
- Share new guard across admin and challenge routers

## Testing
- `pip install requests`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4071861ac832ea6a5e08695803d40