### PR TITLE
Force PWA cache update

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,7 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.3/workbox-sw.js');
 
 // This value is replaced at build time by tools/update_sw_version.py
-const CACHE_VERSION = 'c82fa5272184';
+const CACHE_VERSION = '85c925e07ef0';
 
 self.addEventListener('install', () => self.skipWaiting());
 


### PR DESCRIPTION
## Summary
- bump the service worker cache version so installed PWAs pick up the latest assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00aa64ce0832ebdcb2236c29cac64