### PR TITLE
Restrict service worker navigation handling to same-origin requests

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -36,7 +36,7 @@ workbox.precaching.precacheAndRoute([
 
 // index.html and navigation requests: Network First
 workbox.routing.registerRoute(
-  ({ request }) => request.mode === 'navigate',
+  ({ request, url }) => request.mode === 'navigate' && url.origin === self.location.origin,
   new workbox.strategies.NetworkFirst({ cacheName: 'pages' })
 );
 


### PR DESCRIPTION
## Summary
- limit the service worker navigation route to only handle same-origin pages so embedded iframes are fetched directly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e026258ec0832eaba30a84e0a4cac5