### PR TITLE
Add manifest so the PWA installs with bundled icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Campionat de 3 bandes</title>
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" href="./icons/icon-192.png" sizes="192x192" type="image/png" />
+    <link rel="apple-touch-icon" href="./icons/icon-192x192.png" />
     <style>
       html,
       body {

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,52 @@
+{
+  "name": "Campionat de 3 bandes",
+  "short_name": "3 bandes",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0b3d91",
+  "icons": [
+    {
+      "src": "icons/icon-48x48.png",
+      "sizes": "48x48",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-96x96.png",
+      "sizes": "96x96",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-256x256.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-384x384.png",
+      "sizes": "384x384",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -30,8 +30,17 @@ workbox.precaching.precacheAndRoute([
   { url: './data/classificacions.json', revision: CACHE_VERSION },
   { url: './data/events.json', revision: CACHE_VERSION },
   { url: './data/continu3b.json', revision: CACHE_VERSION },
+  { url: './manifest.webmanifest', revision: CACHE_VERSION },
+  { url: './icons/icon-48x48.png', revision: CACHE_VERSION },
+  { url: './icons/icon-72x72.png', revision: CACHE_VERSION },
+  { url: './icons/icon-96x96.png', revision: CACHE_VERSION },
+  { url: './icons/icon-144x144.png', revision: CACHE_VERSION },
   { url: './icons/icon-192.png', revision: CACHE_VERSION },
-  { url: './icons/icon-512.png', revision: CACHE_VERSION }
+  { url: './icons/icon-192x192.png', revision: CACHE_VERSION },
+  { url: './icons/icon-256x256.png', revision: CACHE_VERSION },
+  { url: './icons/icon-384x384.png', revision: CACHE_VERSION },
+  { url: './icons/icon-512.png', revision: CACHE_VERSION },
+  { url: './icons/icon-512x512.png', revision: CACHE_VERSION }
 ]);
 
 // index.html and navigation requests: Network First


### PR DESCRIPTION
## Summary
- add a web app manifest that enumerates the available application icons
- register the manifest and installation icons in the HTML entry point
- precache the manifest and icon assets in the service worker for offline availability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e028103318832e91d74c99b3167a0a